### PR TITLE
Simplify login redirect and broaden main page access

### DIFF
--- a/includes/login.php
+++ b/includes/login.php
@@ -23,35 +23,15 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 		$_SESSION['NombreDelUsuario'] = $NombreDelUsuario;
 		$_SESSION['TipoDeUsuario'] = $data['TipoDeUsuario'];
 		$_SESSION['NombreCliente'] = $data['NombreCliente'];
-		$_SESSION['CLIENTEID'] = $data['CLIENTEID'];
+               $_SESSION['CLIENTEID'] = $data['CLIENTEID'];
 
+               header('Location: main.php');
+               exit;
+        } else { // Unsuccessful!
 
-                if ($_SERVER['HTTP_HOST'] == "local.edison:8888") {
-
-                        echo "<script>window.location.href='http://local.edison:8888/main.php';</script>";
-                        exit;
-                } else if ($_SERVER['HTTP_HOST'] == "localhost") {
-
-                        echo "<script>window.location.href='http://localhost/DesarrolloWeb/edisonreparto/main.php';</script>";
-                        exit;
-                } else {
-
-                        echo "<script>window.location.href='https://reparto.edison.com.mx/main.php';</script>";
-                        exit;
-                }
-	} else { // Unsuccessful!
-
-		if ($_SERVER['HTTP_HOST'] == "local.edison:8888") {
-			echo "<script>window.location.href='http://local.edison:8888/index.php?login=no';</script>";
-			exit;
-		} else if ($_SERVER['HTTP_HOST'] == "localhost/edisonreparto") {
-			echo "<script>window.location.href=''http://localhost/index.php?login=no';</script>";
-			exit;
-		} else {
-			echo "<script>window.location.href='https://reparto.edison.com.mx/index.php?login=no';</script>";
-			exit;
-		}
-	}
+               header('Location: index.php?login=no');
+               exit;
+        }
 
 	mysqli_close($conn); // Close the database connection.
 

--- a/main.php
+++ b/main.php
@@ -1,7 +1,8 @@
 <?php include("includes/HeaderScripts.php");
 
-if ($_SESSION['TIPOUSUARIO'] != 1) {
+if (!in_array((int)$_SESSION['TIPOUSUARIO'], [1, 2, 3, 4], true)) {
     header("Location: index.php");
+    exit;
 }
 
 ?>


### PR DESCRIPTION
## Summary
- Replace host-based login redirects with a single universal `header('Location: main.php')` flow
- Broaden main dashboard access to allow multiple user roles

## Testing
- `php -l includes/login.php`
- `php -l main.php`


------
https://chatgpt.com/codex/tasks/task_e_68923b38b7c88327bd05de969fdf1b35