### PR TITLE
Fix login redirect to main application page

### DIFF
--- a/includes/login_functions.inc.php
+++ b/includes/login_functions.inc.php
@@ -1,28 +1,15 @@
 <?php
 function redirect_user($page = 'index.php')
 {
+        // Determine the protocol being used
+        $protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https://' : 'http://';
 
-	// Start defining the URL...
-	// URL is http:// plus the host name plus the current directory:
+        // Build the URL relative to the domain root
+        $url = $protocol . $_SERVER['HTTP_HOST'] . '/' . ltrim($page, '/');
 
-
-	if ($_SERVER['HTTP_HOST'] == "local.edison:8888") {
-		$url = 'http://' . $_SERVER['HTTP_HOST'] . dirname($_SERVER['PHP_SELF']);
-	} else if ($_SERVER['HTTP_HOST'] == "localhost") {
-		$url = 'http://' . $_SERVER['HTTP_HOST'] . dirname($_SERVER['PHP_SELF']);
-	} else {
-		$url = 'https://' . $_SERVER['HTTP_HOST'] . dirname($_SERVER['PHP_SELF']);
-	}
-
-	// Remove any trailing slashes:
-	$url = rtrim($url, '/\\');
-
-	// Add the page:
-	$url .= '/' . $page;
-
-	// Redirect the user:
-	header("Location: $url");
-	exit(); // Quit the script.
+        // Redirect the user
+        header("Location: $url");
+        exit(); // Quit the script.
 
 } // End of redirect_user() function.
 


### PR DESCRIPTION
## Summary
- build redirect URLs from domain root to prevent `/includes` in path

## Testing
- `php -l includes/login_functions.inc.php`
- `composer validate --no-check-publish`
- `composer install`

------
https://chatgpt.com/codex/tasks/task_e_6892783f04848327ac2c2c826c6df893