### PR TITLE
Improve app page layout and dynamic titles

### DIFF
--- a/Repartos.php
+++ b/Repartos.php
@@ -1,5 +1,7 @@
 <?php include("includes/HeaderScripts.php");
 
+$pageTitle = 'Edison - Reparto';
+
 $query_clientes = "SELECT * FROM clientes";
 $clientes = mysqli_query($conn, $query_clientes) or die(mysqli_error($conn));
 $totalRows_clientes = mysqli_num_rows($clientes);

--- a/charolas.php
+++ b/charolas.php
@@ -1,4 +1,6 @@
 <?php include("includes/HeaderScripts.php");
+
+$pageTitle = 'Edison - Charolas';
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/includes/Header.php
+++ b/includes/Header.php
@@ -8,7 +8,7 @@
     <!-- The above 6 meta tags *must* come first in the head; any other head content must come *after* these tags -->
 
     <!-- Title -->
-    <title>Edison - Reparto</title>
+    <title><?php echo $pageTitle ?? 'Edison - Reparto'; ?></title>
 
     <!-- Styles -->
     <link rel="preconnect" href="https://fonts.gstatic.com">

--- a/main.php
+++ b/main.php
@@ -1,5 +1,7 @@
 <?php include("includes/HeaderScripts.php");
 
+$pageTitle = 'Edison - Apps';
+
 if (!in_array((int)$_SESSION['TIPOUSUARIO'], [1, 2, 3, 4], true)) {
     header("Location: index.php");
     exit;
@@ -37,14 +39,24 @@ if (!in_array((int)$_SESSION['TIPOUSUARIO'], [1, 2, 3, 4], true)) {
                     <div class="container-fluid">
                         <div class="row">
                             <div class="col">
-                                <div class="page-description">
+                                <div class="page-description text-center">
                                     <h1>Aplicaciones</h1>
-                                    <div class="row">
+                                    <div class="row justify-content-center">
                                         <div class="col-md-6 mb-3">
-                                            <a href="Repartos.php" class="btn btn-primary btn-lg w-100">EdisonReparto</a>
+                                            <a href="Repartos.php" class="card text-decoration-none text-dark">
+                                                <div class="card-body">
+                                                    <i class="material-icons-two-tone" style="font-size:72px;">local_shipping</i>
+                                                    <h5 class="mt-3">Reparto</h5>
+                                                </div>
+                                            </a>
                                         </div>
                                         <div class="col-md-6 mb-3">
-                                            <a href="charolas.php" class="btn btn-primary btn-lg w-100">Charolas</a>
+                                            <a href="charolas.php" class="card text-decoration-none text-dark">
+                                                <div class="card-body">
+                                                    <i class="material-icons-two-tone" style="font-size:72px;">view_day</i>
+                                                    <h5 class="mt-3">Charolas</h5>
+                                                </div>
+                                            </a>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
## Summary
- center main app header and replace text buttons with icon-based cards
- support per-page titles via `$pageTitle` and update main, Reparto and Charolas pages

## Testing
- `php -l includes/Header.php main.php Repartos.php charolas.php`


------
https://chatgpt.com/codex/tasks/task_e_6892810758a88327a116de1724cbc9af