### PR TITLE
Make app icons transparent and tighten spacing

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1050,7 +1050,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .app-menu>ul>li>a>i:not(.has-sub-menu) {
-    margin-right: 13px;
+    margin-right: 5px;
     vertical-align: top;
     line-height: 20px;
     filter: invert(41%) sepia(17%) saturate(674%) hue-rotate(182deg) brightness(95%) contrast(89%);

--- a/assets/css/main.min.css
+++ b/assets/css/main.min.css
@@ -830,7 +830,7 @@ h6 {
     brightness(109%) contrast(115%);
 }
 .app-menu > ul > li > a > i:not(.has-sub-menu) {
-  margin-right: 13px;
+  margin-right: 5px;
   vertical-align: top;
   line-height: 20px;
   filter: invert(41%) sepia(17%) saturate(674%) hue-rotate(182deg)

--- a/main.php
+++ b/main.php
@@ -43,18 +43,18 @@ if (!in_array((int)$_SESSION['TIPOUSUARIO'], [1, 2, 3, 4], true)) {
                                     <h1>Aplicaciones</h1>
                                     <div class="row justify-content-center">
                                         <div class="col-md-6 mb-3">
-                                            <a href="Repartos.php" class="card text-decoration-none text-dark">
+                                            <a href="Repartos.php" class="card text-decoration-none text-dark bg-transparent border-0">
                                                 <div class="card-body">
                                                     <i class="material-icons-two-tone" style="font-size:72px;">local_shipping</i>
-                                                    <h5 class="mt-3">Reparto</h5>
+                                                    <h5 class="mt-1">Reparto</h5>
                                                 </div>
                                             </a>
                                         </div>
                                         <div class="col-md-6 mb-3">
-                                            <a href="charolas.php" class="card text-decoration-none text-dark">
+                                            <a href="charolas.php" class="card text-decoration-none text-dark bg-transparent border-0">
                                                 <div class="card-body">
                                                     <i class="material-icons-two-tone" style="font-size:72px;">view_day</i>
-                                                    <h5 class="mt-3">Charolas</h5>
+                                                    <h5 class="mt-1">Charolas</h5>
                                                 </div>
                                             </a>
                                         </div>


### PR DESCRIPTION
## Summary
- remove card backgrounds and tighten spacing beneath main app icons
- reduce sidebar icon margin to bring labels closer

## Testing
- `composer validate`
- `php -l main.php`


------
https://chatgpt.com/codex/tasks/task_e_689283a901308327ab76421df7d561c1