### PR TITLE
Refine application cards and menu label

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -27,3 +27,19 @@
     padding: 10px 30px;
 }
 /* Your Custom CSS Goes here */
+
+.app-card {
+    box-shadow: none !important;
+    border: none;
+    border-radius: 0;
+    width: 150px;
+    height: 150px;
+}
+
+.app-card .card-body {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+}

--- a/includes/Menu.php
+++ b/includes/Menu.php
@@ -4,7 +4,7 @@
             Apps
         </li> -->
         <li>
-            <a href="main.php"><i class="material-icons-two-tone">dashboard</i>Dashboard</a>
+            <a href="main.php"><i class="material-icons-two-tone">dashboard</i>Aplicaciones</a>
         </li>
         <li>
             <a href="charolas.php"><i class="material-icons-two-tone">view_day</i>Charolas</a>

--- a/main.php
+++ b/main.php
@@ -41,17 +41,17 @@ if (!in_array((int)$_SESSION['TIPOUSUARIO'], [1, 2, 3, 4], true)) {
                             <div class="col">
                                 <div class="page-description text-center">
                                     <h1>Aplicaciones</h1>
-                                    <div class="row justify-content-center">
-                                        <div class="col-md-6 mb-3">
-                                            <a href="Repartos.php" class="card text-decoration-none text-dark bg-transparent border-0">
+                                    <div class="row justify-content-center mt-4">
+                                        <div class="col-auto mb-3">
+                                            <a href="Repartos.php" class="card app-card text-decoration-none text-dark bg-transparent border-0">
                                                 <div class="card-body">
                                                     <i class="material-icons-two-tone" style="font-size:72px;">local_shipping</i>
                                                     <h5 class="mt-1">Reparto</h5>
                                                 </div>
                                             </a>
                                         </div>
-                                        <div class="col-md-6 mb-3">
-                                            <a href="charolas.php" class="card text-decoration-none text-dark bg-transparent border-0">
+                                        <div class="col-auto mb-3">
+                                            <a href="charolas.php" class="card app-card text-decoration-none text-dark bg-transparent border-0">
                                                 <div class="card-body">
                                                     <i class="material-icons-two-tone" style="font-size:72px;">view_day</i>
                                                     <h5 class="mt-1">Charolas</h5>


### PR DESCRIPTION
## Summary
- remove card shadows and size buttons into 150px squares
- add spacing below "Aplicaciones" heading
- rename menu Dashboard item to Aplicaciones

## Testing
- `php -l includes/Menu.php`
- `php -l main.php`


------
https://chatgpt.com/codex/tasks/task_e_6892881d9bc08327b71fce2840a222c8