### PR TITLE
Fix client number duplication issues

### DIFF
--- a/App/Server/ServerInfoClientesChecarCLCSIANSiExiste.php
+++ b/App/Server/ServerInfoClientesChecarCLCSIANSiExiste.php
@@ -3,17 +3,16 @@
 include("../../Connections/ConDB.php");
 // Definir La table de la base de datos
 
+$CLCSIANDeCliente = $_POST['CLCSIAN'];
 
-$SIANDeCliente = $_POST['CLIENTESIAN'];
-
-if ($SIANDeCliente != "" && $SIANDeCliente != "0") {
-    $sql = "SELECT * FROM clientes WHERE clientes.CLIENTESIAN = '$SIANDeCliente'";
+if ($CLCSIANDeCliente != "" && $CLCSIANDeCliente != "0") {
+    $sql = "SELECT * FROM clientes WHERE clientes.CLCSIAN = '$CLCSIANDeCliente'";
     $status = mysqli_query($conn, $sql) or die("database error:" . mysqli_error($conn));
     $row = mysqli_fetch_array($status);
 
     $msg = array(
         'CLIENTEID' => $row['CLIENTEID'],
-        'CLIENTESIAN' => $row['CLIENTESIAN'],
+        'CLCSIAN' => $row['CLCSIAN'],
         'NombreCliente' => $row['NombreCliente'],
         'EmailCliente' => $row['EmailCliente'],
         'TelefonoCliente' => $row['TelefonoCliente'],

--- a/App/Server/ServerInsertarClientes.php
+++ b/App/Server/ServerInsertarClientes.php
@@ -3,8 +3,12 @@
 include("../../Connections/ConDB.php");
 include("../../includes/Funciones.php");
 
-$CLIENTESIAN = mysqli_real_escape_string($conn, $_POST['CLIENTESIAN']);
-$CLCSIAN = isset($_POST['CLCSIAN']) ? mysqli_real_escape_string($conn, $_POST['CLCSIAN']) : NULL;
+$CLIENTESIAN = (isset($_POST['CLIENTESIAN']) && $_POST['CLIENTESIAN'] !== '')
+    ? "'" . mysqli_real_escape_string($conn, $_POST['CLIENTESIAN']) . "'"
+    : "NULL";
+$CLCSIAN = (isset($_POST['CLCSIAN']) && $_POST['CLCSIAN'] !== '')
+    ? "'" . mysqli_real_escape_string($conn, $_POST['CLCSIAN']) . "'"
+    : "NULL";
 
 $NombreCliente = isset($_POST['NombreCliente']) ? mysqli_real_escape_string($conn, $_POST['NombreCliente']) : NULL;
 
@@ -16,7 +20,7 @@ $ColoniaCliente = isset($_POST['ColoniaCliente']) ? mysqli_real_escape_string($c
 $CiudadCliente = isset($_POST['CiudadCliente']) ? mysqli_real_escape_string($conn, $_POST['CiudadCliente']) : NULL;
 $EstadoCliente = isset($_POST['EstadoCliente']) ? mysqli_real_escape_string($conn, $_POST['EstadoCliente']) : NULL;
 
-$sql = "INSERT INTO clientes (CLIENTESIAN,CLCSIAN, NombreCliente, EmailCliente, TelefonoCliente, NombreContacto, DireccionCliente, ColoniaCliente, CiudadCliente, EstadoCliente) VALUES ('$CLIENTESIAN', '$CLCSIAN', '$NombreCliente', '$EmailCliente', '$TelefonoCliente', '$NombreContacto', '$DireccionCliente', '$ColoniaCliente', '$CiudadCliente', '$EstadoCliente')";
+$sql = "INSERT INTO clientes (CLIENTESIAN,CLCSIAN, NombreCliente, EmailCliente, TelefonoCliente, NombreContacto, DireccionCliente, ColoniaCliente, CiudadCliente, EstadoCliente) VALUES ($CLIENTESIAN, $CLCSIAN, '$NombreCliente', '$EmailCliente', '$TelefonoCliente', '$NombreContacto', '$DireccionCliente', '$ColoniaCliente', '$CiudadCliente', '$EstadoCliente')";
 
 if (!mysqli_query($conn, $sql)) {
     die('Error: ' . mysqli_error($conn));

--- a/App/Server/ServerUpdateClientes.php
+++ b/App/Server/ServerUpdateClientes.php
@@ -2,9 +2,13 @@
 
 include("../../Connections/ConDB.php");
 
-$CLIENTESIANEditar = mysqli_real_escape_string($conn, $_POST['CLIENTESIANEditar']);
+$CLIENTESIANEditar = (isset($_POST['CLIENTESIANEditar']) && $_POST['CLIENTESIANEditar'] !== '')
+    ? "'" . mysqli_real_escape_string($conn, $_POST['CLIENTESIANEditar']) . "'"
+    : "NULL";
 
-$CLCSIANEditar = mysqli_real_escape_string($conn, $_POST['CLCSIANEditar']);
+$CLCSIANEditar = (isset($_POST['CLCSIANEditar']) && $_POST['CLCSIANEditar'] !== '')
+    ? "'" . mysqli_real_escape_string($conn, $_POST['CLCSIANEditar']) . "'"
+    : "NULL";
 
 $NombreClienteEditar = mysqli_real_escape_string($conn, $_POST['NombreClienteEditar']);
 $EmailClienteEditar = mysqli_real_escape_string($conn, $_POST['EmailClienteEditar']);
@@ -18,9 +22,9 @@ $EstadoClienteEditar = mysqli_real_escape_string($conn, $_POST['EstadoClienteEdi
 $CLIENTEIDEditar = mysqli_real_escape_string($conn, $_POST['CLIENTEIDEditar']);
 
 // Build the base query
-$sql = "UPDATE clientes SET 
-    CLIENTESIAN = '$CLIENTESIANEditar',
-    CLCSIAN = '$CLCSIANEditar',
+$sql = "UPDATE clientes SET
+    CLIENTESIAN = $CLIENTESIANEditar,
+    CLCSIAN = $CLCSIANEditar,
     NombreCliente = '$NombreClienteEditar',
     TelefonoCliente = '$TelefonoClienteEditar',
     NombreContacto = '$NombreContactoEditar',

--- a/App/js/AppClientes.js
+++ b/App/js/AppClientes.js
@@ -226,38 +226,40 @@ $(document).ready(function() {
 
   // Función que se llama cuando el usuario deja de escribir
   function doneTyping() {
-    $.ajax({
-      //async: false,
-      type: "POST",
-      url: "App/Server/ServerInfoClientesChecarSIANSiExiste.php",
-      data: "CLIENTESIAN=" + ValorClienteSIAN,
-      dataType: "json",
-      success: function(response) {
-        // Reescribe la Datatable y le da refresh
+    if (ValorClienteSIAN !== "" && ValorClienteSIAN !== "0") {
+      $.ajax({
+        //async: false,
+        type: "POST",
+        url: "App/Server/ServerInfoClientesChecarSIANSiExiste.php",
+        data: "CLIENTESIAN=" + ValorClienteSIAN,
+        dataType: "json",
+        success: function(response) {
+          // Reescribe la Datatable y le da refresh
 
-        if (response.NombreCliente != null) {
-          // Mandar el modal de que ya existe el email
+          if (response.NombreCliente != null) {
+            // Mandar el modal de que ya existe el email
 
-          $("#ModalYaExiste").modal("show");
+            $("#ModalYaExiste").modal("show");
 
-          // Quitamos el modal que genero el email
+            // Quitamos el modal que genero el email
 
-          $("#ModalAgregarClientes").modal("hide");
+            $("#ModalAgregarClientes").modal("hide");
 
-          // Mandamos la informacion al nuevo modal
+            // Mandamos la informacion al nuevo modal
 
-          $("#NumeroDeClienteSIANYaExiste").text(response.CLIENTESIAN);
-          $("#NombreClienteYaExiste").text(response.NombreCliente);
-          $("#EmailClienteYaExiste").text(response.EmailCliente);
-          $("#TelefonoClienteYaExiste").text(response.TelefonoCliente);
-          $("#NombreContactoYaExiste").text(response.NombreContacto);
-          $("#DireccionClienteYaExiste").text(response.DireccionCliente);
-          $("#ColoniaClienteYaExiste").text(response.ColoniaCliente);
-          $("#CiudadClienteYaExiste").text(response.CiudadCliente);
-          $("#EstadoClienteYaExiste").text(response.EstadoCliente);
-        }
-      },
-    }).done(function() {});
+            $("#NumeroDeClienteSIANYaExiste").text(response.CLIENTESIAN);
+            $("#NombreClienteYaExiste").text(response.NombreCliente);
+            $("#EmailClienteYaExiste").text(response.EmailCliente);
+            $("#TelefonoClienteYaExiste").text(response.TelefonoCliente);
+            $("#NombreContactoYaExiste").text(response.NombreContacto);
+            $("#DireccionClienteYaExiste").text(response.DireccionCliente);
+            $("#ColoniaClienteYaExiste").text(response.ColoniaCliente);
+            $("#CiudadClienteYaExiste").text(response.CiudadCliente);
+            $("#EstadoClienteYaExiste").text(response.EstadoCliente);
+          }
+        },
+      }).done(function() {});
+    }
   }
 
   // Disparo el modal #ModalAgregarClientes cuano cierro #ModalEmailYaExiste


### PR DESCRIPTION
## Summary
- Treat missing CLIENTESIAN and CLCSIAN as NULL when inserting or updating clients
- Skip duplicate lookups for empty or zero client numbers and credit numbers
- Avoid front-end CLIENTESIAN lookups when the field is blank or zero

## Testing
- `php -l App/Server/ServerInsertarClientes.php`
- `php -l App/Server/ServerUpdateClientes.php`
- `php -l App/Server/ServerInfoClientesChecarSIANSiExiste.php`
- `php -l App/Server/ServerInfoClientesChecarCLCSIANSiExiste.php`


------
https://chatgpt.com/codex/tasks/task_e_6893a10be4008327b8fd41b2f7be06d3