### PR TITLE
Fix login background image distortion

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -6407,9 +6407,8 @@ span.flatpickr-weekday {
 }
 
 .app-auth-sign-in .app-auth-background {
-    background: url('../../App/Graficos/Background/BackIndex.jpg') no-repeat;
-    background-size: 100%;
-    background-position: center;
+    /* Use a cover background to avoid distortion of the login image */
+    background: url('../../App/Graficos/Background/BackIndex.jpg') center/cover no-repeat;
 }
 
 

--- a/assets/css/main.min.css
+++ b/assets/css/main.min.css
@@ -5943,11 +5943,7 @@ span.flatpickr-weekday {
   content: "";
   display: block;
 }
-.app-auth-sign-in .app-auth-background {
-  background: url(../../App/Graficos/Background/BackIndex.jpg) no-repeat;
-  background-size: 60%;
-  background-position: center;
-}
+.app-auth-sign-in .app-auth-background{background:url(../../App/Graficos/Background/BackIndex.jpg) center/cover no-repeat;}
 .app-auth-sign-up .app-auth-background {
   background: url(../images/backgrounds/sign-up.svg) no-repeat;
   background-size: 60%;


### PR DESCRIPTION
## Summary
- Prevent login background image from stretching by using `center/cover` background styling.

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_689618d511ec8327b3563fb3594f11bf