### PR TITLE
Add tray assembly requisition feature

### DIFF
--- a/App/Server/ServerInfoOrdenesCharolas.php
+++ b/App/Server/ServerInfoOrdenesCharolas.php
@@ -1,0 +1,17 @@
+<?php
+include("../../Connections/ConDB.php");
+
+$query = "SELECT oc.ORDENCHAROLAID, oc.Cantidad, oc.STATUSID, s.Status, c.SkuCharolas, c.DescripcionCharolas
+          FROM ordenes_charolas oc
+          JOIN charolas c ON c.CHAROLASID = oc.CHAROLASID
+          JOIN status s ON s.STATUSID = oc.STATUSID
+          ORDER BY oc.ORDENCHAROLAID DESC";
+$result = mysqli_query($conn, $query) or die(mysqli_error($conn));
+$ordenes = array();
+while ($row = mysqli_fetch_assoc($result)) {
+    $ordenes[] = $row;
+}
+echo json_encode($ordenes);
+
+mysqli_close($conn);
+?>

--- a/App/Server/ServerInsertarOrdenCharolas.php
+++ b/App/Server/ServerInsertarOrdenCharolas.php
@@ -1,0 +1,16 @@
+<?php
+include("../../Connections/ConDB.php");
+
+$CHAROLASID = mysqli_real_escape_string($conn, $_POST['CHAROLASID']);
+$Cantidad = mysqli_real_escape_string($conn, $_POST['Cantidad']);
+
+$sql = "INSERT INTO ordenes_charolas (CHAROLASID, Cantidad, STATUSID) VALUES ('$CHAROLASID', '$Cantidad', 1)";
+if (!mysqli_query($conn, $sql)) {
+    die('Error: ' . mysqli_error($conn));
+}
+
+$msg = array('ORDENCHAROLAID' => mysqli_insert_id($conn));
+echo json_encode($msg);
+
+mysqli_close($conn);
+?>

--- a/App/Server/ServerUpdateOrdenCharolas.php
+++ b/App/Server/ServerUpdateOrdenCharolas.php
@@ -1,0 +1,16 @@
+<?php
+include("../../Connections/ConDB.php");
+
+$ORDENCHAROLAID = mysqli_real_escape_string($conn, $_POST['ORDENCHAROLAID']);
+$STATUSID = mysqli_real_escape_string($conn, $_POST['STATUSID']);
+
+$sql = "UPDATE ordenes_charolas SET STATUSID = '$STATUSID' WHERE ORDENCHAROLAID = '$ORDENCHAROLAID'";
+if (!mysqli_query($conn, $sql)) {
+    die('Error: ' . mysqli_error($conn));
+}
+
+$msg = array('ORDENCHAROLAID' => $ORDENCHAROLAID);
+echo json_encode($msg);
+
+mysqli_close($conn);
+?>

--- a/App/js/AppCharolas.js
+++ b/App/js/AppCharolas.js
@@ -5,6 +5,35 @@ $(document).ready(function() {
     width: '100%'
   });
 
+  function cargarOrdenes() {
+    $.ajax({
+      url: 'App/Server/ServerInfoOrdenesCharolas.php',
+      dataType: 'json',
+      success: function(response) {
+        var tbody = $('#TablaOrdenesCharolas tbody');
+        tbody.empty();
+
+        $.each(response, function(index, item) {
+          var opciones = '';
+          $.each(statusOptions, function(i, status) {
+            var seleccionado = status.STATUSID == item.STATUSID ? 'selected' : '';
+            opciones += '<option value="' + status.STATUSID + '" ' + seleccionado + '>' + status.Status + '</option>';
+          });
+
+          var fila = '<tr>' +
+            '<td>' + item.SkuCharolas + '</td>' +
+            '<td>' + item.DescripcionCharolas + '</td>' +
+            '<td>' + item.Cantidad + '</td>' +
+            '<td><select class="form-select status-select" data-order="' + item.ORDENCHAROLAID + '">' + opciones + '</select></td>' +
+            '</tr>';
+          tbody.append(fila);
+        });
+      }
+    });
+  }
+
+  cargarOrdenes();
+
   $('#CalcularBtn').on('click', function() {
     var charolaId = $('#CHAROLASID').val();
     var cantidad = $('#CantidadCharolas').val();
@@ -31,5 +60,38 @@ $(document).ready(function() {
         }
       });
     }
+  });
+
+  $('#GenerarRequisicionBtn').on('click', function() {
+    var charolaId = $('#CHAROLASID').val();
+    var cantidad = $('#CantidadCharolas').val();
+
+    if (charolaId && cantidad && cantidad > 0) {
+      $.ajax({
+        type: 'POST',
+        url: 'App/Server/ServerInsertarOrdenCharolas.php',
+        data: { CHAROLASID: charolaId, Cantidad: cantidad },
+        dataType: 'json',
+        success: function() {
+          $('#CantidadCharolas').val('');
+          cargarOrdenes();
+        }
+      });
+    }
+  });
+
+  $('#TablaOrdenesCharolas').on('change', '.status-select', function() {
+    var orderId = $(this).data('order');
+    var statusId = $(this).val();
+
+    $.ajax({
+      type: 'POST',
+      url: 'App/Server/ServerUpdateOrdenCharolas.php',
+      data: { ORDENCHAROLAID: orderId, STATUSID: statusId },
+      dataType: 'json',
+      success: function() {
+        cargarOrdenes();
+      }
+    });
   });
 });

--- a/charolas.php
+++ b/charolas.php
@@ -6,6 +6,14 @@ $pageTitle = 'Edison - Charolas';
 $query_charolas = "SELECT * FROM charolas";
 $charolas = mysqli_query($conn, $query_charolas) or die(mysqli_error($conn));
 $totalRows_charolas = mysqli_num_rows($charolas);
+
+// Obtener estatus disponibles para las requisiciones
+$query_status = "SELECT * FROM status";
+$status = mysqli_query($conn, $query_status) or die(mysqli_error($conn));
+$status_options = [];
+while ($row_status = mysqli_fetch_assoc($status)) {
+    $status_options[] = $row_status;
+}
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -51,6 +59,11 @@ $totalRows_charolas = mysqli_num_rows($charolas);
                                 <button type="button" class="btn btn-primary w-100" id="CalcularBtn">Calcular</button>
                             </div>
                         </div>
+                        <div class="row mb-4">
+                            <div class="col-md-3 ms-auto">
+                                <button type="button" class="btn btn-success w-100" id="GenerarRequisicionBtn">Generar requisición</button>
+                            </div>
+                        </div>
                         <div class="row">
                             <div class="col">
                                 <table class="table" id="TablaMateriaPrima">
@@ -64,6 +77,22 @@ $totalRows_charolas = mysqli_num_rows($charolas);
                                     </thead>
                                     <tbody>
                                     </tbody>
+                                </table>
+                            </div>
+                        </div>
+                        <div class="row mt-4">
+                            <div class="col">
+                                <h5>Requisiciones de armado</h5>
+                                <table class="table" id="TablaOrdenesCharolas">
+                                    <thead>
+                                        <tr>
+                                            <th>SKU</th>
+                                            <th>Descripción</th>
+                                            <th>Cantidad</th>
+                                            <th>Estatus</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody></tbody>
                                 </table>
                             </div>
                         </div>
@@ -83,6 +112,9 @@ $totalRows_charolas = mysqli_num_rows($charolas);
     <script src="assets/js/main.min.js"></script>
     <script src="assets/js/custom.js"></script>
     <script src="assets/js/select2.min.js" integrity="sha512-9p/L4acAjbjIaaGXmZf0Q2bV42HetlCLbv8EP0z3rLbQED2TAFUlDvAezy7kumYqg5T8jHtDdlm1fgIsr5QzKg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script>
+        var statusOptions = <?php echo json_encode($status_options); ?>;
+    </script>
     <script src="App/js/AppCharolas.js"></script>
     <script src="App/js/AppCambiarContrasena.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- allow users to create assembly requisitions for charolas and list them with status controls
- provide server endpoints to insert, list and update requisition records

## Testing
- `php -l charolas.php`
- `php -l App/Server/ServerInsertarOrdenCharolas.php`
- `php -l App/Server/ServerInfoOrdenesCharolas.php`
- `php -l App/Server/ServerUpdateOrdenCharolas.php`


------
https://chatgpt.com/codex/tasks/task_e_6896212a15148327b6dcdb59b361b883