### PR TITLE
Add expandable material details to charolas orders table

### DIFF
--- a/App/Server/ServerInfoOrdenesCharolas.php
+++ b/App/Server/ServerInfoOrdenesCharolas.php
@@ -1,7 +1,8 @@
 <?php
 include("../../Connections/ConDB.php");
 
-$query = "SELECT oc.ORDENCHAROLAID, oc.Cantidad, oc.STATUSID, s.Status, c.SkuCharolas, c.DescripcionCharolas
+
+$query = "SELECT oc.ORDENCHAROLAID, oc.CHAROLASID, oc.Cantidad, oc.STATUSID, s.Status, c.SkuCharolas, c.DescripcionCharolas
           FROM ordenes_charolas oc
           JOIN charolas c ON c.CHAROLASID = oc.CHAROLASID
           JOIN status s ON s.STATUSID = oc.STATUSID
@@ -9,6 +10,21 @@ $query = "SELECT oc.ORDENCHAROLAID, oc.Cantidad, oc.STATUSID, s.Status, c.SkuCha
 $result = mysqli_query($conn, $query) or die(mysqli_error($conn));
 $ordenes = array();
 while ($row = mysqli_fetch_assoc($result)) {
+    $detalles = array();
+    $sqlDetalles = "SELECT mp.SkuMP, mp.DescripcionMP, mp.TipoMP, cc.CANTIDAD
+                    FROM cantidadcharolas cc
+                    INNER JOIN materiaprimacharolas mp ON cc.MATERIAPRIMAID = mp.MATERIAPRIMAID
+                    WHERE cc.CHAROLASID = " . $row['CHAROLASID'];
+    $resultDetalles = mysqli_query($conn, $sqlDetalles) or die(mysqli_error($conn));
+    while ($det = mysqli_fetch_assoc($resultDetalles)) {
+        $detalles[] = array(
+            'SkuMP' => $det['SkuMP'],
+            'DescripcionMP' => $det['DescripcionMP'],
+            'TipoMP' => $det['TipoMP'],
+            'Cantidad' => intval($det['CANTIDAD']) * intval($row['Cantidad'])
+        );
+    }
+    $row['Detalles'] = $detalles;
     $ordenes[] = $row;
 }
 echo json_encode($ordenes);

--- a/App/js/AppCharolas.js
+++ b/App/js/AppCharolas.js
@@ -32,26 +32,51 @@ $(document).ready(function() {
       success: function(response) {
         if (tablaOrdenes) {
           tablaOrdenes.clear().destroy();
+          $('#TablaOrdenesCharolas tbody').empty();
         }
-
-        var tbody = $('#TablaOrdenesCharolas tbody');
-        tbody.empty();
-
-        $.each(response, function(index, item) {
-          var fila = '<tr>' +
-            '<td>' + item.SkuCharolas + '</td>' +
-            '<td>' + item.DescripcionCharolas + '</td>' +
-            '<td>' + item.Cantidad + '</td>' +
-            '<td>' + obtenerBadge(item.STATUSID, item.ORDENCHAROLAID) + '</td>' +
-            '</tr>';
-          tbody.append(fila);
-        });
 
         tablaOrdenes = $('#TablaOrdenesCharolas').DataTable({
           dom: 'Bfrtip',
           buttons: ['excelHtml5', 'pageLength'],
-          responsive: true,
+          data: response,
           pageLength: 100,
+          responsive: {
+            details: {
+              type: 'column',
+              renderer: function(api, rowIdx, columns) {
+                var data = api.row(rowIdx).data();
+                if (!data.Detalles || !data.Detalles.length) {
+                  return '';
+                }
+                var html = '<table class="table table-sm"><thead><tr>' +
+                  '<th>SKU MP</th><th>Descripción</th><th>Tipo</th><th>Cantidad</th>' +
+                  '</tr></thead><tbody>';
+                $.each(data.Detalles, function(i, mp) {
+                  html += '<tr>' +
+                    '<td>' + mp.SkuMP + '</td>' +
+                    '<td>' + mp.DescripcionMP + '</td>' +
+                    '<td>' + mp.TipoMP + '</td>' +
+                    '<td>' + mp.Cantidad + '</td>' +
+                    '</tr>';
+                });
+                html += '</tbody></table>';
+                return html;
+              }
+            }
+          },
+          order: [1, 'asc'],
+          columns: [
+            { className: 'dtr-control', orderable: false, data: null, defaultContent: '' },
+            { data: 'SkuCharolas' },
+            { data: 'DescripcionCharolas' },
+            { data: 'Cantidad' },
+            {
+              data: null,
+              render: function(data, type, row) {
+                return obtenerBadge(row.STATUSID, row.ORDENCHAROLAID);
+              }
+            }
+          ],
           language: {
             search: 'Búsqueda:',
             lengthMenu: 'Mostrar _MENU_ filas',

--- a/charolas.php
+++ b/charolas.php
@@ -78,6 +78,7 @@ $totalRows_charolas = mysqli_num_rows($charolas);
                                 <table class="table" id="TablaOrdenesCharolas">
                                     <thead>
                                         <tr>
+                                            <th></th>
                                             <th>SKU</th>
                                             <th>Descripción</th>
                                             <th>Cantidad</th>


### PR DESCRIPTION
## Summary
- add expandable details control in charolas orders table
- compute and return raw material requirements for each order
- render raw material breakdown as child rows in the DataTable
- fix column alignment so SKU, description, quantity, and status display under correct headers

## Testing
- `php -l charolas.php`
- `php -l App/Server/ServerInfoOrdenesCharolas.php`
- `node --check App/js/AppCharolas.js`


------
https://chatgpt.com/codex/tasks/task_e_689a1cb3f3a88327ba6adbf633407f96