### PR TITLE
Add expandable details for Charolas orders

### DIFF
--- a/App/js/AppCharolas.js
+++ b/App/js/AppCharolas.js
@@ -40,6 +40,24 @@ $(document).ready(function() {
           buttons: ['excelHtml5', 'pageLength'],
           data: response,
           pageLength: 100,
+          order: [1, 'asc'],
+          columns: [
+            {
+              className: 'dtr-control',
+              orderable: false,
+              data: null,
+              defaultContent: ''
+            },
+            { data: 'SkuCharolas' },
+            { data: 'DescripcionCharolas' },
+            { data: 'Cantidad' },
+            {
+              data: null,
+              render: function(data, type, row) {
+                return obtenerBadge(row.STATUSID, row.ORDENCHAROLAID);
+              }
+            }
+          ],
           responsive: {
             details: {
               type: 'column',
@@ -65,22 +83,6 @@ $(document).ready(function() {
               }
             }
           },
-          columnDefs: [
-            { className: 'dtr-control', orderable: false, targets: 0 }
-          ],
-          order: [1, 'asc'],
-          columns: [
-            { data: null, defaultContent: '' },
-            { data: 'SkuCharolas' },
-            { data: 'DescripcionCharolas' },
-            { data: 'Cantidad' },
-            {
-              data: null,
-              render: function(data, type, row) {
-                return obtenerBadge(row.STATUSID, row.ORDENCHAROLAID);
-              }
-            }
-          ],
           language: {
             search: 'Búsqueda:',
             lengthMenu: 'Mostrar _MENU_ filas',

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -43,3 +43,16 @@
     justify-content: center;
     height: 100%;
 }
+
+/* Estilos para el botón de detalles de DataTables */
+table.dataTable.dtr-inline.collapsed>tbody>tr>td.dtr-control:before,
+table.dataTable.dtr-inline.collapsed>tbody>tr>th.dtr-control:before {
+    background-color: #198754; /* verde */
+    color: #fff;
+}
+
+table.dataTable.dtr-inline.collapsed>tbody>tr.parent>td.dtr-control:before,
+table.dataTable.dtr-inline.collapsed>tbody>tr.parent>th.dtr-control:before {
+    background-color: #dc3545; /* rojo */
+    color: #fff;
+}

--- a/charolas.php
+++ b/charolas.php
@@ -78,7 +78,7 @@ $totalRows_charolas = mysqli_num_rows($charolas);
                                 <table class="table" id="TablaOrdenesCharolas">
                                     <thead>
                                         <tr>
-                                            <th></th>
+                                            <th class="dtr-control"></th>
                                             <th>SKU</th>
                                             <th>Descripción</th>
                                             <th>Cantidad</th>


### PR DESCRIPTION
## Summary
- add detail-control column to Charolas orders table
- configure DataTables to render raw material requirements in expandable rows
- style plus/minus indicators for DataTables detail toggles

## Testing
- `php -l charolas.php`
- `node --check App/js/AppCharolas.js`


------
https://chatgpt.com/codex/tasks/task_e_689a23b8a17c8327ae1b8e17672a12e1