### PR TITLE
feat: add details button for charola records

### DIFF
--- a/App/Modales/ModalesCharolas.php
+++ b/App/Modales/ModalesCharolas.php
@@ -26,3 +26,27 @@
         </div>
     </div>
 </div>
+
+<div class="modal" id="ModalDetallesCharola">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Detalles de la charola</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="btn-close"></button>
+            </div>
+            <div class="modal-body">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>SKU MP</th>
+                            <th>Descripción</th>
+                            <th>Tipo</th>
+                            <th>Cantidad</th>
+                        </tr>
+                    </thead>
+                    <tbody id="DetalleCharolaTBody"></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>

--- a/App/js/AppCharolas.js
+++ b/App/js/AppCharolas.js
@@ -53,6 +53,11 @@ $(document).ready(function() {
             { data: 'Cantidad' },
             {
               data: null,
+              orderable: false,
+              defaultContent: '<button class="btn btn-sm btn-info btn-ver-detalles">Ver</button>'
+            },
+            {
+              data: null,
               render: function(data, type, row) {
                 return obtenerBadge(row.STATUSID, row.ORDENCHAROLAID);
               }
@@ -148,6 +153,25 @@ $(document).ready(function() {
         }
       });
     }
+  });
+
+  $('#TablaOrdenesCharolas').on('click', '.btn-ver-detalles', function() {
+    var tr = $(this).closest('tr');
+    var data = tablaOrdenes.row(tr).data();
+    var tbody = $('#DetalleCharolaTBody');
+    tbody.empty();
+    if (data && data.Detalles) {
+      $.each(data.Detalles, function(i, mp) {
+        var fila = '<tr>' +
+          '<td>' + mp.SkuMP + '</td>' +
+          '<td>' + mp.DescripcionMP + '</td>' +
+          '<td>' + mp.TipoMP + '</td>' +
+          '<td>' + mp.Cantidad + '</td>' +
+          '</tr>';
+        tbody.append(fila);
+      });
+    }
+    $('#ModalDetallesCharola').modal('show');
   });
 
   $('#TablaOrdenesCharolas').on('click', '.badge-status', function() {

--- a/charolas.php
+++ b/charolas.php
@@ -82,6 +82,7 @@ $totalRows_charolas = mysqli_num_rows($charolas);
                                             <th>SKU</th>
                                             <th>Descripción</th>
                                             <th>Cantidad</th>
+                                            <th>Detalles</th>
                                             <th>Estatus</th>
                                         </tr>
                                     </thead>


### PR DESCRIPTION
## Summary
- add Detalles column for charola requisitions table
- implement modal to display material details
- hook JS logic to populate modal from each record

## Testing
- `php -l charolas.php`
- `php -l App/Modales/ModalesCharolas.php`
- `node --check App/js/AppCharolas.js`


------
https://chatgpt.com/codex/tasks/task_e_689a3a4913a48327a74736025c6a7b37