### PR TITLE
Agregar columna de requisición y quitar detalles en charolas

### DIFF
--- a/App/js/AppCharolas.js
+++ b/App/js/AppCharolas.js
@@ -40,7 +40,7 @@ $(document).ready(function() {
           buttons: ['excelHtml5', 'pageLength'],
           data: response,
           pageLength: 100,
-          order: [1, 'asc'],
+          order: [1, 'desc'],
           columns: [
             {
               className: 'dtr-control',
@@ -48,14 +48,10 @@ $(document).ready(function() {
               data: null,
               defaultContent: ''
             },
+            { data: 'ORDENCHAROLAID' },
             { data: 'SkuCharolas' },
             { data: 'DescripcionCharolas' },
             { data: 'Cantidad' },
-            {
-              data: null,
-              orderable: false,
-              defaultContent: '<button class="btn btn-sm btn-info btn-ver-detalles">Ver</button>'
-            },
             {
               data: null,
               render: function(data, type, row) {
@@ -153,25 +149,6 @@ $(document).ready(function() {
         }
       });
     }
-  });
-
-  $('#TablaOrdenesCharolas').on('click', '.btn-ver-detalles', function() {
-    var tr = $(this).closest('tr');
-    var data = tablaOrdenes.row(tr).data();
-    var tbody = $('#DetalleCharolaTBody');
-    tbody.empty();
-    if (data && data.Detalles) {
-      $.each(data.Detalles, function(i, mp) {
-        var fila = '<tr>' +
-          '<td>' + mp.SkuMP + '</td>' +
-          '<td>' + mp.DescripcionMP + '</td>' +
-          '<td>' + mp.TipoMP + '</td>' +
-          '<td>' + mp.Cantidad + '</td>' +
-          '</tr>';
-        tbody.append(fila);
-      });
-    }
-    $('#ModalDetallesCharola').modal('show');
   });
 
   $('#TablaOrdenesCharolas').on('click', '.badge-status', function() {

--- a/charolas.php
+++ b/charolas.php
@@ -79,10 +79,10 @@ $totalRows_charolas = mysqli_num_rows($charolas);
                                     <thead>
                                         <tr>
                                             <th class="dtr-control"></th>
+                                            <th>Requisición</th>
                                             <th>SKU</th>
                                             <th>Descripción</th>
                                             <th>Cantidad</th>
-                                            <th>Detalles</th>
                                             <th>Estatus</th>
                                         </tr>
                                     </thead>


### PR DESCRIPTION
## Summary
- Mostrar el ID de la requisición en una nueva columna inicial
- Quitar la columna de detalles del listado de charolas
- Ordenar las requisiciones de forma descendente por su ID

## Testing
- `php -l charolas.php`
- `node --check App/js/AppCharolas.js`


------
https://chatgpt.com/codex/tasks/task_e_689a3d4c18108327aef9ebd21aa871bb