### PR TITLE
Add viewing/reactivation of deleted Material Pendiente records (UI + server endpoints)

### DIFF
--- a/App/Server/ServerListarMaterialPendienteEliminado.php
+++ b/App/Server/ServerListarMaterialPendienteEliminado.php
@@ -1,0 +1,139 @@
+<?php
+
+include("../../Connections/ConDB.php");
+
+header('Content-Type: application/json');
+
+function responderError(string $mensaje, int $codigo = 400): void
+{
+    http_response_code($codigo);
+    echo json_encode(['success' => false, 'message' => $mensaje]);
+    exit;
+}
+
+function obtenerTipoUsuarioActual(mysqli $conn): string
+{
+    $tipoSesion = strtolower(trim((string) ($_SESSION['TipoDeUsuario'] ?? '')));
+    if ($tipoSesion !== '') {
+        return $tipoSesion;
+    }
+
+    $tipoUsuarioSesionId = (int) ($_SESSION['TIPOUSUARIO'] ?? 0);
+    if ($tipoUsuarioSesionId <= 0) {
+        return '';
+    }
+
+    $consulta = mysqli_prepare(
+        $conn,
+        'SELECT TipoDeUsuario FROM tipodeusuarios WHERE TIPODEUSUARIOID = ? LIMIT 1'
+    );
+
+    if (!$consulta) {
+        return '';
+    }
+
+    mysqli_stmt_bind_param($consulta, 'i', $tipoUsuarioSesionId);
+    mysqli_stmt_execute($consulta);
+    mysqli_stmt_bind_result($consulta, $tipoUsuarioRecuperado);
+
+    $tipo = '';
+    if (mysqli_stmt_fetch($consulta)) {
+        $tipo = strtolower(trim((string) $tipoUsuarioRecuperado));
+    }
+
+    mysqli_stmt_close($consulta);
+
+    return $tipo;
+}
+
+function obtenerNombreBaseDatos(mysqli $conn, ?string $actual): string
+{
+    if (!empty($actual)) {
+        return (string) $actual;
+    }
+
+    $resultado = mysqli_query($conn, 'SELECT DATABASE()');
+    if ($resultado instanceof mysqli_result) {
+        $fila = mysqli_fetch_row($resultado);
+        mysqli_free_result($resultado);
+        if ($fila && isset($fila[0])) {
+            return (string) $fila[0];
+        }
+    }
+
+    return '';
+}
+
+function asegurarColumnaActivo(mysqli $conn, string $baseDatos, string $tabla, string $columna, string $sqlAlter): void
+{
+    if ($baseDatos === '') {
+        return;
+    }
+
+    $stmtColumna = mysqli_prepare(
+        $conn,
+        'SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND COLUMN_NAME = ? LIMIT 1'
+    );
+
+    if (!$stmtColumna) {
+        return;
+    }
+
+    mysqli_stmt_bind_param($stmtColumna, 'sss', $baseDatos, $tabla, $columna);
+    mysqli_stmt_execute($stmtColumna);
+    mysqli_stmt_store_result($stmtColumna);
+
+    if (mysqli_stmt_num_rows($stmtColumna) === 0) {
+        @mysqli_query($conn, $sqlAlter);
+    }
+
+    mysqli_stmt_close($stmtColumna);
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
+    responderError('Método no permitido.', 405);
+}
+
+if (!$conn) {
+    responderError('No se pudo conectar a la base de datos.', 500);
+}
+
+$tipoUsuarioActual = obtenerTipoUsuarioActual($conn);
+if ($tipoUsuarioActual !== 'soporte it') {
+    responderError('No cuentas con permisos para consultar registros eliminados.', 403);
+}
+
+$nombreBaseDatos = obtenerNombreBaseDatos($conn, $dbname ?? '');
+asegurarColumnaActivo($conn, $nombreBaseDatos, 'facturamp', 'ActivoFMP', "ALTER TABLE facturamp ADD COLUMN ActivoFMP TINYINT(1) NOT NULL DEFAULT 1 AFTER AduanaFMP");
+asegurarColumnaActivo($conn, $nombreBaseDatos, 'materialpendiente', 'ActivoMP', "ALTER TABLE materialpendiente ADD COLUMN ActivoMP TINYINT(1) NOT NULL DEFAULT 1 AFTER FechaMP");
+
+$sql = "SELECT f.FacturaMPID, f.FechaFMP, f.DocumentoFMP, f.RazonSocialFMP, f.ClienteFMP,
+        (SELECT COUNT(*) FROM materialpendiente mp WHERE mp.DocumentoMP = f.DocumentoFMP AND mp.ActivoMP = 0) AS PartidasInactivas
+    FROM facturamp f
+    WHERE f.ActivoFMP = 0
+    ORDER BY f.FacturaMPID DESC";
+
+$resultado = mysqli_query($conn, $sql);
+
+if (!$resultado) {
+    responderError('No se pudieron obtener los registros eliminados.', 500);
+}
+
+$registros = [];
+while ($fila = mysqli_fetch_assoc($resultado)) {
+    $registros[] = [
+        'folio' => isset($fila['FacturaMPID']) ? (int) $fila['FacturaMPID'] : 0,
+        'fecha' => (string) ($fila['FechaFMP'] ?? ''),
+        'documento' => (string) ($fila['DocumentoFMP'] ?? ''),
+        'razonSocial' => (string) ($fila['RazonSocialFMP'] ?? ''),
+        'cliente' => (string) ($fila['ClienteFMP'] ?? ''),
+        'partidasInactivas' => isset($fila['PartidasInactivas']) ? (int) $fila['PartidasInactivas'] : 0,
+    ];
+}
+
+mysqli_free_result($resultado);
+
+echo json_encode([
+    'success' => true,
+    'records' => $registros,
+]);

--- a/App/Server/ServerReactivarMaterialPendiente.php
+++ b/App/Server/ServerReactivarMaterialPendiente.php
@@ -1,0 +1,172 @@
+<?php
+
+include("../../Connections/ConDB.php");
+
+header('Content-Type: application/json');
+
+function responderError(string $mensaje, int $codigo = 400): void
+{
+    http_response_code($codigo);
+    echo json_encode(['success' => false, 'message' => $mensaje]);
+    exit;
+}
+
+function obtenerTipoUsuarioActual(mysqli $conn): string
+{
+    $tipoSesion = strtolower(trim((string) ($_SESSION['TipoDeUsuario'] ?? '')));
+    if ($tipoSesion !== '') {
+        return $tipoSesion;
+    }
+
+    $tipoUsuarioSesionId = (int) ($_SESSION['TIPOUSUARIO'] ?? 0);
+    if ($tipoUsuarioSesionId <= 0) {
+        return '';
+    }
+
+    $consulta = mysqli_prepare(
+        $conn,
+        'SELECT TipoDeUsuario FROM tipodeusuarios WHERE TIPODEUSUARIOID = ? LIMIT 1'
+    );
+
+    if (!$consulta) {
+        return '';
+    }
+
+    mysqli_stmt_bind_param($consulta, 'i', $tipoUsuarioSesionId);
+    mysqli_stmt_execute($consulta);
+    mysqli_stmt_bind_result($consulta, $tipoUsuarioRecuperado);
+
+    $tipo = '';
+    if (mysqli_stmt_fetch($consulta)) {
+        $tipo = strtolower(trim((string) $tipoUsuarioRecuperado));
+    }
+
+    mysqli_stmt_close($consulta);
+
+    return $tipo;
+}
+
+function obtenerNombreBaseDatos(mysqli $conn, ?string $actual): string
+{
+    if (!empty($actual)) {
+        return (string) $actual;
+    }
+
+    $resultado = mysqli_query($conn, 'SELECT DATABASE()');
+    if ($resultado instanceof mysqli_result) {
+        $fila = mysqli_fetch_row($resultado);
+        mysqli_free_result($resultado);
+        if ($fila && isset($fila[0])) {
+            return (string) $fila[0];
+        }
+    }
+
+    return '';
+}
+
+function asegurarColumnaActivo(mysqli $conn, string $baseDatos, string $tabla, string $columna, string $sqlAlter): void
+{
+    if ($baseDatos === '') {
+        return;
+    }
+
+    $stmtColumna = mysqli_prepare(
+        $conn,
+        'SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND COLUMN_NAME = ? LIMIT 1'
+    );
+
+    if (!$stmtColumna) {
+        return;
+    }
+
+    mysqli_stmt_bind_param($stmtColumna, 'sss', $baseDatos, $tabla, $columna);
+    mysqli_stmt_execute($stmtColumna);
+    mysqli_stmt_store_result($stmtColumna);
+
+    if (mysqli_stmt_num_rows($stmtColumna) === 0) {
+        @mysqli_query($conn, $sqlAlter);
+    }
+
+    mysqli_stmt_close($stmtColumna);
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    responderError('Método no permitido.', 405);
+}
+
+if (!$conn) {
+    responderError('No se pudo conectar a la base de datos.', 500);
+}
+
+$tipoUsuarioActual = obtenerTipoUsuarioActual($conn);
+if ($tipoUsuarioActual !== 'soporte it') {
+    responderError('No cuentas con permisos para reactivar registros.', 403);
+}
+
+$nombreBaseDatos = obtenerNombreBaseDatos($conn, $dbname ?? '');
+asegurarColumnaActivo($conn, $nombreBaseDatos, 'facturamp', 'ActivoFMP', "ALTER TABLE facturamp ADD COLUMN ActivoFMP TINYINT(1) NOT NULL DEFAULT 1 AFTER AduanaFMP");
+asegurarColumnaActivo($conn, $nombreBaseDatos, 'materialpendiente', 'ActivoMP', "ALTER TABLE materialpendiente ADD COLUMN ActivoMP TINYINT(1) NOT NULL DEFAULT 1 AFTER FechaMP");
+
+$folio = isset($_POST['folio']) ? (int) $_POST['folio'] : 0;
+if ($folio <= 0) {
+    responderError('Folio inválido.', 400);
+}
+
+$stmtFactura = mysqli_prepare($conn, 'SELECT DocumentoFMP FROM facturamp WHERE FacturaMPID = ? LIMIT 1');
+if (!$stmtFactura) {
+    responderError('No se pudo consultar el folio solicitado.', 500);
+}
+
+mysqli_stmt_bind_param($stmtFactura, 'i', $folio);
+mysqli_stmt_execute($stmtFactura);
+mysqli_stmt_bind_result($stmtFactura, $documento);
+
+if (!mysqli_stmt_fetch($stmtFactura)) {
+    mysqli_stmt_close($stmtFactura);
+    responderError('No se encontró el folio solicitado.', 404);
+}
+
+mysqli_stmt_close($stmtFactura);
+$documento = (string) $documento;
+
+mysqli_begin_transaction($conn);
+
+$stmtReactivarFactura = mysqli_prepare($conn, 'UPDATE facturamp SET ActivoFMP = 1 WHERE FacturaMPID = ? LIMIT 1');
+if (!$stmtReactivarFactura) {
+    mysqli_rollback($conn);
+    responderError('No se pudo reactivar el folio.', 500);
+}
+
+mysqli_stmt_bind_param($stmtReactivarFactura, 'i', $folio);
+$okFactura = mysqli_stmt_execute($stmtReactivarFactura);
+mysqli_stmt_close($stmtReactivarFactura);
+
+if (!$okFactura) {
+    mysqli_rollback($conn);
+    responderError('No se pudo reactivar el folio.', 500);
+}
+
+$stmtReactivarPartidas = mysqli_prepare($conn, 'UPDATE materialpendiente SET ActivoMP = 1 WHERE DocumentoMP = ?');
+if (!$stmtReactivarPartidas) {
+    mysqli_rollback($conn);
+    responderError('No se pudieron reactivar las partidas del documento.', 500);
+}
+
+mysqli_stmt_bind_param($stmtReactivarPartidas, 's', $documento);
+$okPartidas = mysqli_stmt_execute($stmtReactivarPartidas);
+$partidasAfectadas = mysqli_stmt_affected_rows($stmtReactivarPartidas);
+mysqli_stmt_close($stmtReactivarPartidas);
+
+if (!$okPartidas) {
+    mysqli_rollback($conn);
+    responderError('No se pudieron reactivar las partidas del documento.', 500);
+}
+
+mysqli_commit($conn);
+
+echo json_encode([
+    'success' => true,
+    'folio' => $folio,
+    'documento' => $documento,
+    'partidasReactivadas' => max(0, (int) $partidasAfectadas),
+]);

--- a/App/js/AppMaterialPendiente.js
+++ b/App/js/AppMaterialPendiente.js
@@ -48,6 +48,9 @@ $(document).ready(function() {
   var $resumenPaginacionMaterialPendiente = $('#ResumenPaginacionMaterialPendiente');
   var $btnPaginaAnterior = $('#MaterialPendientePaginaAnterior');
   var $btnPaginaSiguiente = $('#MaterialPendientePaginaSiguiente');
+  var $modalEliminados = $('#ModalMaterialPendienteEliminado');
+  var $tablaEliminadosBody = $('#TablaMaterialPendienteEliminadoBody');
+  var $errorEliminados = $('#MaterialPendienteEliminadoError');
   var REGISTROS_POR_PAGINA = 5;
   var paginaActualMaterialPendiente = 1;
   var $panelDetalle = $('#PanelEntregaMaterialPendiente');
@@ -1035,6 +1038,125 @@ $(document).ready(function() {
     window.alert(texto);
   }
 
+  function mostrarErrorEliminados(mensaje) {
+    if (!$errorEliminados.length) {
+      mostrarMensajeError(mensaje);
+      return;
+    }
+
+    $errorEliminados.removeClass('d-none').text((mensaje || '').toString().trim() || 'No se pudo completar la operación.');
+  }
+
+  function ocultarErrorEliminados() {
+    if ($errorEliminados.length) {
+      $errorEliminados.addClass('d-none').text('');
+    }
+  }
+
+  function formatearFechaEliminado(fecha) {
+    if (!fecha) {
+      return '-';
+    }
+
+    var valor = String(fecha).replace(' ', 'T');
+    var fechaObjeto = new Date(valor);
+
+    if (isNaN(fechaObjeto.getTime())) {
+      return fecha;
+    }
+
+    return fechaObjeto.toLocaleString('es-MX', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  }
+
+  function renderizarRegistrosEliminados(registros) {
+    if (!$tablaEliminadosBody.length) {
+      return;
+    }
+
+    if (!registros || !registros.length) {
+      $tablaEliminadosBody.html('<tr><td colspan="6" class="text-center text-muted">No hay registros eliminados para mostrar.</td></tr>');
+      return;
+    }
+
+    var filas = registros.map(function(registro) {
+      var folio = registro && registro.folio ? parseInt(registro.folio, 10) : 0;
+      var documento = registro && registro.documento ? registro.documento : '';
+      var partidasInactivas = registro && registro.partidasInactivas ? parseInt(registro.partidasInactivas, 10) : 0;
+      var textoPartidas = partidasInactivas > 0 ? ' (' + partidasInactivas + ' partidas)' : '';
+
+      return '<tr>' +
+        '<td>' + (folio > 0 ? folio : '-') + '</td>' +
+        '<td>' + escaparHtml(formatearFechaEliminado(registro && registro.fecha ? registro.fecha : '')) + '</td>' +
+        '<td>' + escaparHtml(documento || '-') + '</td>' +
+        '<td>' + escaparHtml((registro && registro.razonSocial) || '-') + '</td>' +
+        '<td>' + escaparHtml((registro && registro.cliente) || '-') + '</td>' +
+        '<td class="text-end">' +
+          '<button type="button" class="btn btn-sm btn-outline-success reactivar-material-pendiente" data-folio="' + folio + '" data-documento="' + escaparHtml(documento) + '">' +
+            '<i class="material-icons-two-tone">restore</i> Reactivar' + escaparHtml(textoPartidas) +
+          '</button>' +
+        '</td>' +
+      '</tr>';
+    }).join('');
+
+    $tablaEliminadosBody.html(filas);
+  }
+
+  function cargarRegistrosEliminados() {
+    if (!$tablaEliminadosBody.length) {
+      return;
+    }
+
+    ocultarErrorEliminados();
+    $tablaEliminadosBody.html('<tr><td colspan="6" class="text-center text-muted">Cargando registros eliminados…</td></tr>');
+
+    $.ajax({
+      url: 'App/Server/ServerListarMaterialPendienteEliminado.php',
+      method: 'GET',
+      dataType: 'json'
+    }).done(function(respuesta) {
+      if (!respuesta || !respuesta.success) {
+        mostrarErrorEliminados(respuesta && respuesta.message ? respuesta.message : 'No se pudieron cargar los registros eliminados.');
+        $tablaEliminadosBody.html('<tr><td colspan="6" class="text-center text-muted">No se pudieron cargar los registros eliminados.</td></tr>');
+        return;
+      }
+
+      renderizarRegistrosEliminados(respuesta.records || []);
+    }).fail(function() {
+      mostrarErrorEliminados('No se pudieron cargar los registros eliminados.');
+      $tablaEliminadosBody.html('<tr><td colspan="6" class="text-center text-muted">No se pudieron cargar los registros eliminados.</td></tr>');
+    });
+  }
+
+  function reactivarRegistroEliminado(folio) {
+    if (!folio || folio <= 0) {
+      return;
+    }
+
+    ocultarErrorEliminados();
+
+    $.ajax({
+      url: 'App/Server/ServerReactivarMaterialPendiente.php',
+      method: 'POST',
+      dataType: 'json',
+      data: { folio: folio }
+    }).done(function(respuesta) {
+      if (!respuesta || !respuesta.success) {
+        mostrarErrorEliminados(respuesta && respuesta.message ? respuesta.message : 'No se pudo reactivar el registro.');
+        return;
+      }
+
+      window.location.reload();
+    }).fail(function() {
+      mostrarErrorEliminados('No se pudo reactivar el registro.');
+    });
+  }
+
   function mostrarAdvertenciaDocumentoDuplicado(documento) {
     documentoDuplicadoDetectado = true;
 
@@ -1677,6 +1799,28 @@ $(document).ready(function() {
       }).fail(function() {
         mostrarMensajeError('No se pudo eliminar el registro.');
       });
+    });
+  }
+
+  if ($modalEliminados.length) {
+    $modalEliminados.on('show.bs.modal', function() {
+      cargarRegistrosEliminados();
+    });
+
+    $tablaEliminadosBody.on('click', '.reactivar-material-pendiente', function() {
+      var folio = parseInt($(this).data('folio'), 10);
+      var documento = ($(this).data('documento') || '').toString().trim();
+      var mensaje = '¿Deseas reactivar este registro eliminado?';
+
+      if (documento !== '') {
+        mensaje += ' Documento: ' + documento + '.';
+      }
+
+      if (!window.confirm(mensaje)) {
+        return;
+      }
+
+      reactivarRegistroEliminado(folio);
     });
   }
 

--- a/MaterialPendiente.php
+++ b/MaterialPendiente.php
@@ -7,6 +7,30 @@ if (!usuarioTieneAccesoSeccion('materialpendiente')) {
     exit;
 }
 
+$tipoUsuarioActual = strtolower(trim((string)($_SESSION['TipoDeUsuario'] ?? '')));
+$tipoUsuarioSesionId = (int)($_SESSION['TIPOUSUARIO'] ?? 0);
+
+if ($tipoUsuarioActual === '' && $tipoUsuarioSesionId > 0) {
+    $consultaTipoUsuario = mysqli_prepare(
+        $conn,
+        'SELECT TipoDeUsuario FROM tipodeusuarios WHERE TIPODEUSUARIOID = ? LIMIT 1'
+    );
+
+    if ($consultaTipoUsuario) {
+        mysqli_stmt_bind_param($consultaTipoUsuario, 'i', $tipoUsuarioSesionId);
+        mysqli_stmt_execute($consultaTipoUsuario);
+        mysqli_stmt_bind_result($consultaTipoUsuario, $tipoUsuarioRecuperado);
+
+        if (mysqli_stmt_fetch($consultaTipoUsuario)) {
+            $tipoUsuarioActual = strtolower(trim((string) $tipoUsuarioRecuperado));
+        }
+
+        mysqli_stmt_close($consultaTipoUsuario);
+    }
+}
+
+$esSoporteITMaterialPendiente = $tipoUsuarioActual === 'soporte it';
+
 $hayProductosPendientes = false;
 $queryProductosPendientes = "SELECT PRODUCTOSID FROM productos LIMIT 1";
 $resultadoProductosPendientes = mysqli_query($conn, $queryProductosPendientes);
@@ -310,6 +334,12 @@ if (isset($_SESSION['TIPOUSUARIO']) && (int) $_SESSION['TIPOUSUARIO'] === 3) {
                                     <i class="material-icons-two-tone">file_download</i>
                                     Exportar Excel
                                 </a>
+                                <?php if ($esSoporteITMaterialPendiente) : ?>
+                                    <button type="button" class="btn btn-sm btn-outline-warning waves-effect width-md waves-light ms-2" id="BtnVerEliminadosMaterialPendiente" data-bs-toggle="modal" data-bs-target="#ModalMaterialPendienteEliminado">
+                                        <i class="material-icons-two-tone">restore_from_trash</i>
+                                        Ver eliminados
+                                    </button>
+                                <?php endif; ?>
                             </div>
                         </div>
 
@@ -519,6 +549,45 @@ if (isset($_SESSION['TIPOUSUARIO']) && (int) $_SESSION['TIPOUSUARIO'] === 3) {
     </div>
 
     <?php include("App/Modales/ModalesMaterialPendiente.php") ?>
+
+    <?php if ($esSoporteITMaterialPendiente) : ?>
+        <div class="modal fade" id="ModalMaterialPendienteEliminado" tabindex="-1" aria-labelledby="ModalMaterialPendienteEliminadoLabel" aria-hidden="true">
+            <div class="modal-dialog modal-xl modal-dialog-scrollable">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="ModalMaterialPendienteEliminadoLabel">Registros eliminados de Material Pendiente</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p class="text-muted mb-3">Solo Soporte IT puede reactivar folios eliminados.</p>
+                        <div class="alert alert-danger d-none" id="MaterialPendienteEliminadoError" role="alert"></div>
+                        <div class="table-responsive">
+                            <table class="table table-sm align-middle mb-0" id="TablaMaterialPendienteEliminado">
+                                <thead>
+                                    <tr>
+                                        <th>Folio</th>
+                                        <th>Fecha</th>
+                                        <th>Documento</th>
+                                        <th>Razón social</th>
+                                        <th>Cliente</th>
+                                        <th class="text-end">Acciones</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="TablaMaterialPendienteEliminadoBody">
+                                    <tr>
+                                        <td colspan="6" class="text-center text-muted">Abre esta ventana para cargar los registros eliminados.</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-light" data-bs-dismiss="modal">Cerrar</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    <?php endif; ?>
 
     <!-- Javascripts -->
     <script src="assets/plugins/jquery/jquery-3.5.1.min.js"></script>


### PR DESCRIPTION
### Motivation
- Provide a way for Soporte IT to list and reactivate deleted "Material Pendiente" folios and their related partidas without modifying normal user workflows.
- Ensure database schema compatibility by safely adding `ActivoFMP` and `ActivoMP` columns when missing to support soft-delete/reactivation.

### Description
- Added two server endpoints: `App/Server/ServerListarMaterialPendienteEliminado.php` to list deleted `facturamp` records and `App/Server/ServerReactivarMaterialPendiente.php` to reactivate a folio and its `materialpendiente` partidas inside a transaction, both returning JSON and enforcing `soporte it` permission checks.
- Implemented helper logic in the new endpoints: `obtenerTipoUsuarioActual`, `obtenerNombreBaseDatos`, and `asegurarColumnaActivo` to determine user type, detect current database, and add `ActivoFMP`/`ActivoMP` columns if absent using safe information_schema checks.
- Updated `App/js/AppMaterialPendiente.js` with functions to load deleted records, render the table, show errors, and call the reactivation endpoint with AJAX, plus event bindings for the modal and reactivation button.
- Updated `MaterialPendiente.php` to detect the current user type server-side, show the "Ver eliminados" button only for `soporte it`, and include the modal markup for listing deleted records.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de7a33b444832782e3efc3da1bc072)