### PR TITLE
Fix modal visibility for "Ver eliminados" in Material Pendiente

### DIFF
--- a/App/js/AppMaterialPendiente.js
+++ b/App/js/AppMaterialPendiente.js
@@ -79,6 +79,10 @@ $(document).ready(function() {
   var modoEdicion = false;
   var instanciaModalEliminados = null;
 
+  if ($modalEliminados.length && $modalEliminados.parent()[0] !== document.body) {
+    $modalEliminados.appendTo('body');
+  }
+
   function desplazarASeccionEntrega() {
     if (!$panelDetalle.length) {
       return;
@@ -1825,6 +1829,11 @@ $(document).ready(function() {
   }
 
   if ($modalEliminados.length) {
+    $modalEliminados.on('shown.bs.modal', function() {
+      $modalEliminados.css('z-index', 1060);
+      $('.modal-backdrop').last().css('z-index', 1055);
+    });
+
     $modalEliminados.on('show.bs.modal', function() {
       cargarRegistrosEliminados();
     });

--- a/MaterialPendiente.php
+++ b/MaterialPendiente.php
@@ -564,7 +564,7 @@ if (isset($_SESSION['TIPOUSUARIO']) && (int) $_SESSION['TIPOUSUARIO'] === 3) {
     <?php include("App/Modales/ModalesMaterialPendiente.php") ?>
 
     <?php if ($esSoporteITMaterialPendiente) : ?>
-        <div class="modal fade" id="ModalMaterialPendienteEliminado" tabindex="-1" aria-labelledby="ModalMaterialPendienteEliminadoLabel" aria-hidden="true" style="z-index: 1080;">
+        <div class="modal fade" id="ModalMaterialPendienteEliminado" tabindex="-1" aria-labelledby="ModalMaterialPendienteEliminadoLabel" aria-hidden="true">
             <div class="modal-dialog modal-xl modal-dialog-scrollable">
                 <div class="modal-content">
                     <div class="modal-header">


### PR DESCRIPTION
### Motivation
- El modal de "Ver eliminados" solo mostraba el sombreado porque quedaba atrapado por el contexto de apilamiento del layout, por lo que se buscó que el diálogo se muestre correctamente encima del backdrop.

### Description
- Se eliminó el `style="z-index: 1080;"` inline del `#ModalMaterialPendienteEliminado` en `MaterialPendiente.php`, se mueve el modal al `body` en tiempo de ejecución desde `App/js/AppMaterialPendiente.js` y se agregó un manejador `shown.bs.modal` que ajusta los `z-index` del modal y del último `modal-backdrop` para forzar el orden correcto.

### Testing
- Ejecuté `php -l MaterialPendiente.php` y no se detectaron errores de sintaxis; no se ejecutaron otras pruebas automáticas en este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de83ace1c483278a4262b49229c492)