### PR TITLE
Corregir carga de SMTP y autoload para recuperación de contraseña

### DIFF
--- a/includes/MandarEmail.php
+++ b/includes/MandarEmail.php
@@ -1,6 +1,6 @@
 <?php
 
-require '../../vendor/autoload.php';
+require_once __DIR__ . '/../vendor/autoload.php';
 
 // Instalacion de php Mailer para mandar correos por SMTP ... Se puso el camino completo para que no hubiera problemas cuando se manda desde un Server ... porque es el camino relativo desde esa carpeta ... Pero creo que todas las notificaciones deben de salir asi ... debe de haber una forma de hacerlo Global como la conexion ... pero por ser el primer Script que se hace asi lo mantendremos asi ...
 
@@ -8,6 +8,24 @@ require '../../vendor/autoload.php';
 
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;
+
+function obtenerVariableEntorno($llave, $valorPorDefecto = '')
+{
+    $valor = getenv($llave);
+    if ($valor !== false && $valor !== '') {
+        return $valor;
+    }
+
+    if (isset($_ENV[$llave]) && $_ENV[$llave] !== '') {
+        return $_ENV[$llave];
+    }
+
+    if (isset($_SERVER[$llave]) && $_SERVER[$llave] !== '') {
+        return $_SERVER[$llave];
+    }
+
+    return $valorPorDefecto;
+}
 
 function RecuperaTuPassword($email, $Hash)
 {
@@ -20,11 +38,20 @@ function RecuperaTuPassword($email, $Hash)
         $mail->SMTPAuth   = true;
         $mail->SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS;
 
-        $mail->Username   = getenv('SMTP_USER');
-        $mail->Password   = getenv('SMTP_PASS');
+        $smtpUser = obtenerVariableEntorno('SMTP_USER', 'apps@edison.com.mx');
+        $smtpPass = obtenerVariableEntorno('SMTP_PASS', '');
+        $smtpDebug = obtenerVariableEntorno('APP_DEBUG', '0');
+
+        if ($smtpPass === '') {
+            error_log('PHPMailer CONFIG ERROR: SMTP_PASS no está configurado.');
+            return false;
+        }
+
+        $mail->Username   = $smtpUser;
+        $mail->Password   = $smtpPass;
 
         // Habilitar debug a error_log (Plesk)
-        $mail->SMTPDebug = getenv('APP_DEBUG') === '1' ? 2 : 0;
+        $mail->SMTPDebug = $smtpDebug === '1' ? 2 : 0;
         $mail->Debugoutput = function ($str, $level) {
             error_log("PHPMailer [$level]: $str");
         };


### PR DESCRIPTION
### Motivation

- Arreglar el fallo en el envío del correo de recuperación que se debía a variables SMTP no leídas en algunos entornos y a una ruta relativa frágil para el autoload de Composer. 
- No se utilizó ningún `skill` local porque la modificación es un ajuste puntual al bootstrap de correo. 

### Description

- Cambiado el `require` relativo por `require_once __DIR__ . '/../vendor/autoload.php'` en `includes/MandarEmail.php` para usar una ruta absoluta basada en `__DIR__`. 
- Añadida la función `obtenerVariableEntorno` que resuelve variables de entorno consultando `getenv`, `$_ENV` y `$_SERVER`. 
- Usado el helper para cargar `SMTP_USER`, `SMTP_PASS` y `APP_DEBUG`, con `apps@edison.com.mx` como valor por defecto para `SMTP_USER` y registro en `error_log` y retorno temprano si `SMTP_PASS` está vacío. 
- Conservado el comportamiento de debug de PHPMailer pero ahora parametrizado vía la misma resolución de entorno. 

### Testing

- Ejecutado `php -l includes/MandarEmail.php` y no se detectaron errores de sintaxis. 
- Ejecutado `php -l App/Server/ServerMandarCorreoPassword.php` y no se detectaron errores de sintaxis.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efda6075248327bde256859d6d8e53)