### PR TITLE
Refactor PHPMailer setup: env helper, require path fix, and SMTP fallbacks

### DIFF
--- a/includes/MandarEmail.php
+++ b/includes/MandarEmail.php
@@ -1,6 +1,6 @@
 <?php
 
-require '../../vendor/autoload.php';
+require_once __DIR__ . '/../vendor/autoload.php';
 
 // Instalacion de php Mailer para mandar correos por SMTP ... Se puso el camino completo para que no hubiera problemas cuando se manda desde un Server ... porque es el camino relativo desde esa carpeta ... Pero creo que todas las notificaciones deben de salir asi ... debe de haber una forma de hacerlo Global como la conexion ... pero por ser el primer Script que se hace asi lo mantendremos asi ...
 
@@ -9,44 +9,42 @@ require '../../vendor/autoload.php';
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;
 
+function obtenerVariableEntorno($llave, $valorPorDefecto = '')
+{
+    $valor = getenv($llave);
+    if ($valor !== false && $valor !== '') {
+        return $valor;
+    }
+
+    if (isset($_ENV[$llave]) && $_ENV[$llave] !== '') {
+        return $_ENV[$llave];
+    }
+
+    if (isset($_SERVER[$llave]) && $_SERVER[$llave] !== '') {
+        return $_SERVER[$llave];
+    }
+
+    return $valorPorDefecto;
+}
+
 function RecuperaTuPassword($email, $Hash)
 {
-    $mail = new PHPMailer(true);
+    $smtpUser = obtenerVariableEntorno('SMTP_USER', 'apps@edison.com.mx');
+    $smtpPass = obtenerVariableEntorno('SMTP_PASS', '');
+    $smtpDebug = obtenerVariableEntorno('APP_DEBUG', '0');
 
-    try {
-        $mail->isSMTP();
-        $mail->Host       = 'mail.edison.com.mx';
-        $mail->Port       = 587;
-        $mail->SMTPAuth   = true;
-        $mail->SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS;
+    if ($smtpPass === '') {
+        error_log('PHPMailer CONFIG ERROR: SMTP_PASS no está configurado.');
+        return false;
+    }
 
-        $mail->Username   = getenv('SMTP_USER');
-        $mail->Password   = getenv('SMTP_PASS');
-
-        // Habilitar debug a error_log (Plesk)
-        $mail->SMTPDebug = getenv('APP_DEBUG') === '1' ? 2 : 0;
-        $mail->Debugoutput = function ($str, $level) {
-            error_log("PHPMailer [$level]: $str");
-        };
-
-        $mail->Timeout = 10;
-
-        $mail->setFrom('apps@edison.com.mx', 'Edison Apps');
-        $mail->AuthType = 'LOGIN';
-        $mail->addAddress($email);
-        $mail->Subject = 'Recupera tu contraseña';
-
-        $mail->CharSet = 'UTF-8';
-        $mail->isHTML(true);
-
-        $resetUrl = 'https://apps.edison.com.mx/RecuperarTuPassword.php?HASH=' . urlencode($Hash);
-
-        $mail->Body = '
+    $resetUrl = 'https://apps.edison.com.mx/RecuperarTuPassword.php?HASH=' . urlencode($Hash);
+    $mailBody = '
         <html>
         <body>
             <p>Para recuperar tu contraseña, pulsa el botón:</p>
             <p>
-                <a href="'.$resetUrl.'" target="_blank"
+                <a href="' . $resetUrl . '" target="_blank"
                    style="padding:10px 14px;border-radius:6px;background:#0895ca;color:#fff;text-decoration:none;">
                    Recuperar contraseña
                 </a>
@@ -57,16 +55,57 @@ function RecuperaTuPassword($email, $Hash)
         </body>
         </html>';
 
-        $mail->AltBody = "Recupera tu contraseña aquí: $resetUrl";
+    $estrategiasSmtp = array(
+        array('seguridad' => PHPMailer::ENCRYPTION_STARTTLS, 'puerto' => 587, 'label' => 'STARTTLS-587'),
+        array('seguridad' => PHPMailer::ENCRYPTION_SMTPS, 'puerto' => 465, 'label' => 'SMTPS-465'),
+    );
 
-        $mail->send();
-        return true;
+    foreach ($estrategiasSmtp as $estrategia) {
+        $mail = new PHPMailer(true);
 
-    } catch (Exception $e) {
-        error_log('PHPMailer ERROR: ' . $mail->ErrorInfo);
-        error_log('PHPMailer EXCEPTION: ' . $e->getMessage());
-        return false;
+        try {
+            $mail->isSMTP();
+            $mail->Host       = 'mail.edison.com.mx';
+            $mail->Port       = $estrategia['puerto'];
+            $mail->SMTPAuth   = true;
+            $mail->SMTPSecure = $estrategia['seguridad'];
+            $mail->Username   = $smtpUser;
+            $mail->Password   = $smtpPass;
+
+            // Habilitar debug a error_log (Plesk)
+            $mail->SMTPDebug = $smtpDebug === '1' ? 2 : 0;
+            $mail->Debugoutput = function ($str, $level) {
+                error_log("PHPMailer [$level]: $str");
+            };
+
+            // Algunos servidores cPanel/Plesk usan certificados autofirmados.
+            $mail->SMTPOptions = array(
+                'ssl' => array(
+                    'verify_peer' => false,
+                    'verify_peer_name' => false,
+                    'allow_self_signed' => true,
+                ),
+            );
+
+            $mail->Timeout = 10;
+
+            $mail->setFrom('apps@edison.com.mx', 'Edison Apps');
+            $mail->addAddress($email);
+            $mail->Subject = 'Recupera tu contraseña';
+            $mail->CharSet = 'UTF-8';
+            $mail->isHTML(true);
+            $mail->Body = $mailBody;
+            $mail->AltBody = "Recupera tu contraseña aquí: $resetUrl";
+
+            $mail->send();
+            return true;
+        } catch (Exception $e) {
+            error_log('PHPMailer ERROR [' . $estrategia['label'] . ']: ' . $mail->ErrorInfo);
+            error_log('PHPMailer EXCEPTION [' . $estrategia['label'] . ']: ' . $e->getMessage());
+        }
     }
+
+    return false;
 }
 
 // RecuperaTuPassword('sistemas@edison.com.mx', '123123123');


### PR DESCRIPTION
### Motivation
- Ensure autoload is required reliably from the current script directory and centralize environment lookup for SMTP credentials.
- Improve robustness of password-recovery emails by trying multiple SMTP configurations and tolerating common server cert setups.
- Provide clearer debug/error logging for SMTP attempts to aid diagnosis when deliveries fail.

### Description
- Replaced the relative `require '../../vendor/autoload.php'` with `require_once __DIR__ . '/../vendor/autoload.php'` to reliably load dependencies.
- Added `obtenerVariableEntorno($llave, $valorPorDefecto = '')` to read environment variables from `getenv`, `$_ENV`, or `$_SERVER` with a default fallback.
- Refactored `RecuperaTuPassword($email, $Hash)` to use the env helper, validate presence of `SMTP_PASS`, construct the message body once, and iterate over SMTP strategies (STARTTLS on port 587 and SMTPS on port 465).
- For each strategy a new `PHPMailer` instance is created and configured with `SMTPOptions` that allow self-signed certificates, configurable debug routed to `error_log`, a short timeout, and clearer error logs annotated with the strategy label.
- Function now returns `true` on successful send and `false` after exhausting strategies or if configuration is missing.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efda6075248327bde256859d6d8e53)