### PR TITLE
Persist and display order creator and creation date for charolas

### DIFF
--- a/App/Server/ServerInfoOrdenesCharolas.php
+++ b/App/Server/ServerInfoOrdenesCharolas.php
@@ -117,6 +117,41 @@ function asegurarColumnaFactura($conn)
     return $columnaFactura;
 }
 
+function asegurarColumnaUsuarioCreador($conn)
+{
+    $columnaUsuarioCreador = false;
+
+    $consulta = mysqli_query($conn, "SHOW COLUMNS FROM ordenes_charolas LIKE 'USUARIOIDCreador'");
+    if ($consulta instanceof mysqli_result) {
+        $columnaUsuarioCreador = mysqli_num_rows($consulta) > 0;
+        mysqli_free_result($consulta);
+    }
+
+    if (!$columnaUsuarioCreador) {
+        if (mysqli_query($conn, 'ALTER TABLE ordenes_charolas ADD COLUMN `USUARIOIDCreador` INT NULL')) {
+            $columnaUsuarioCreador = true;
+        }
+    }
+
+    return $columnaUsuarioCreador;
+}
+
+function columnaExiste($conn, $tabla, $columna)
+{
+    $consulta = mysqli_query($conn, sprintf(
+        "SHOW COLUMNS FROM `%s` LIKE '%s'",
+        mysqli_real_escape_string($conn, $tabla),
+        mysqli_real_escape_string($conn, $columna)
+    ));
+    if ($consulta instanceof mysqli_result) {
+        $existe = mysqli_num_rows($consulta) > 0;
+        mysqli_free_result($consulta);
+        return $existe;
+    }
+
+    return false;
+}
+
 function calcularTotalesMateriales($detalles, $cantidadOrden)
 {
     $totales = [
@@ -174,11 +209,17 @@ if (!empty($seleccionAuditado)) {
 
 $columnaFacturaDisponible = asegurarColumnaFactura($conn);
 $seleccionFacturaSql = $columnaFacturaDisponible ? ', oc.Factura AS Factura' : ', NULL AS Factura';
+$columnaUsuarioCreadorDisponible = asegurarColumnaUsuarioCreador($conn);
+$columnaFechaRegistroDisponible = columnaExiste($conn, 'ordenes_charolas', 'FechaRegistro');
+$seleccionUsuarioCreadorSql = $columnaUsuarioCreadorDisponible ? ", TRIM(CONCAT_WS(' ', u.PrimerNombre, u.ApellidoPaterno)) AS UsuarioCreador, oc.USUARIOIDCreador" : ", NULL AS UsuarioCreador, NULL AS USUARIOIDCreador";
+$seleccionFechaRegistroSql = $columnaFechaRegistroDisponible ? ", DATE_FORMAT(oc.FechaRegistro, '%Y-%m-%d %H:%i:%s') AS FechaRegistro" : ', NULL AS FechaRegistro';
+$joinUsuarioCreadorSql = $columnaUsuarioCreadorDisponible ? 'LEFT JOIN usuarios u ON u.USUARIOID = oc.USUARIOIDCreador' : '';
 
-$query = "SELECT oc.ORDENCHAROLAID, oc.CHAROLASID, oc.Cantidad, oc.STATUSID, s.Status, c.SkuCharolas, c.DescripcionCharolas" . $seleccionAuditadoSql . $seleccionFacturaSql . $columnasSeleccionadas . "
+$query = "SELECT oc.ORDENCHAROLAID, oc.CHAROLASID, oc.Cantidad, oc.STATUSID, s.Status, c.SkuCharolas, c.DescripcionCharolas" . $seleccionUsuarioCreadorSql . $seleccionFechaRegistroSql . $seleccionAuditadoSql . $seleccionFacturaSql . $columnasSeleccionadas . "
           FROM ordenes_charolas oc
           JOIN charolas c ON c.CHAROLASID = oc.CHAROLASID
           JOIN status s ON s.STATUSID = oc.STATUSID
+          " . $joinUsuarioCreadorSql . "
           ORDER BY oc.ORDENCHAROLAID DESC";
 $result = mysqli_query($conn, $query);
 if (!$result) {

--- a/App/Server/ServerInsertarOrdenCharolas.php
+++ b/App/Server/ServerInsertarOrdenCharolas.php
@@ -1,5 +1,8 @@
 <?php
 include("../../Connections/ConDB.php");
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
 
 if (!$conn) {
     http_response_code(500);
@@ -50,6 +53,25 @@ function obtenerColumnasMateriales($conn)
     }
 
     return $columnas;
+}
+
+function asegurarColumnaUsuarioCreador($conn)
+{
+    $columnaUsuarioCreador = false;
+
+    $consulta = mysqli_query($conn, "SHOW COLUMNS FROM ordenes_charolas LIKE 'USUARIOIDCreador'");
+    if ($consulta instanceof mysqli_result) {
+        $columnaUsuarioCreador = mysqli_num_rows($consulta) > 0;
+        mysqli_free_result($consulta);
+    }
+
+    if (!$columnaUsuarioCreador) {
+        if (mysqli_query($conn, 'ALTER TABLE ordenes_charolas ADD COLUMN `USUARIOIDCreador` INT NULL')) {
+            $columnaUsuarioCreador = true;
+        }
+    }
+
+    return $columnaUsuarioCreador;
 }
 
 function obtenerDetallesMateriaPrima($conn, $charolasId)
@@ -106,12 +128,18 @@ if ($charolasId <= 0 || $cantidad <= 0) {
 }
 
 $columnasDisponibles = obtenerColumnasMateriales($conn);
+$columnaUsuarioCreadorDisponible = asegurarColumnaUsuarioCreador($conn);
+$usuarioCreadorId = isset($_SESSION['USUARIOID']) ? (int) $_SESSION['USUARIOID'] : 0;
 $columnasMaterialesDisponibles = !in_array(false, $columnasDisponibles, true);
 $detalles = obtenerDetallesMateriaPrima($conn, $charolasId);
 $totales = calcularTotalesMateriales($detalles, $cantidad);
 
 if ($columnasMaterialesDisponibles) {
-    $stmt = mysqli_prepare($conn, "INSERT INTO ordenes_charolas (CHAROLASID, Cantidad, STATUSID, Largueros, Tornilleria, JuntaZeta, Traves) VALUES (?, ?, 1, ?, ?, ?, ?)");
+    if ($columnaUsuarioCreadorDisponible) {
+        $stmt = mysqli_prepare($conn, "INSERT INTO ordenes_charolas (CHAROLASID, Cantidad, STATUSID, Largueros, Tornilleria, JuntaZeta, Traves, USUARIOIDCreador) VALUES (?, ?, 1, ?, ?, ?, ?, ?)");
+    } else {
+        $stmt = mysqli_prepare($conn, "INSERT INTO ordenes_charolas (CHAROLASID, Cantidad, STATUSID, Largueros, Tornilleria, JuntaZeta, Traves) VALUES (?, ?, 1, ?, ?, ?, ?)");
+    }
     if (!$stmt) {
         http_response_code(500);
         echo json_encode(['error' => mysqli_error($conn)]);
@@ -121,7 +149,11 @@ if ($columnasMaterialesDisponibles) {
     $totalTornilleria = (int) $totales['Tornilleria'];
     $totalJuntaZeta = (int) $totales['JuntaZeta'];
     $totalTraves = (int) $totales['Traves'];
-    mysqli_stmt_bind_param($stmt, 'idiiii', $charolasId, $cantidad, $totalLargueros, $totalTornilleria, $totalJuntaZeta, $totalTraves);
+    if ($columnaUsuarioCreadorDisponible) {
+        mysqli_stmt_bind_param($stmt, 'idiiiii', $charolasId, $cantidad, $totalLargueros, $totalTornilleria, $totalJuntaZeta, $totalTraves, $usuarioCreadorId);
+    } else {
+        mysqli_stmt_bind_param($stmt, 'idiiii', $charolasId, $cantidad, $totalLargueros, $totalTornilleria, $totalJuntaZeta, $totalTraves);
+    }
     if (!mysqli_stmt_execute($stmt)) {
         http_response_code(500);
         echo json_encode(['error' => mysqli_stmt_error($stmt)]);
@@ -130,13 +162,21 @@ if ($columnasMaterialesDisponibles) {
     }
     mysqli_stmt_close($stmt);
 } else {
-    $stmt = mysqli_prepare($conn, "INSERT INTO ordenes_charolas (CHAROLASID, Cantidad, STATUSID) VALUES (?, ?, 1)");
+    if ($columnaUsuarioCreadorDisponible) {
+        $stmt = mysqli_prepare($conn, "INSERT INTO ordenes_charolas (CHAROLASID, Cantidad, STATUSID, USUARIOIDCreador) VALUES (?, ?, 1, ?)");
+    } else {
+        $stmt = mysqli_prepare($conn, "INSERT INTO ordenes_charolas (CHAROLASID, Cantidad, STATUSID) VALUES (?, ?, 1)");
+    }
     if (!$stmt) {
         http_response_code(500);
         echo json_encode(['error' => mysqli_error($conn)]);
         exit;
     }
-    mysqli_stmt_bind_param($stmt, 'id', $charolasId, $cantidad);
+    if ($columnaUsuarioCreadorDisponible) {
+        mysqli_stmt_bind_param($stmt, 'idi', $charolasId, $cantidad, $usuarioCreadorId);
+    } else {
+        mysqli_stmt_bind_param($stmt, 'id', $charolasId, $cantidad);
+    }
     if (!mysqli_stmt_execute($stmt)) {
         http_response_code(500);
         echo json_encode(['error' => mysqli_stmt_error($stmt)]);

--- a/App/js/AppCharolas.js
+++ b/App/js/AppCharolas.js
@@ -570,6 +570,8 @@ $(document).ready(function() {
       '<th scope="col">SKU</th>' +
       '<th scope="col">Descripción</th>' +
       '<th scope="col">Cantidad</th>' +
+      '<th scope="col">Usuario</th>' +
+      '<th scope="col">Fecha creación</th>' +
       '<th scope="col">Salida</th>' +
       '<th scope="col">Entrada</th>' +
       '<th scope="col">Almacén</th>' +
@@ -586,7 +588,7 @@ $(document).ready(function() {
       thead.append(encabezado);
     } else {
       var celdas = fila.first().children('th');
-      if (celdas.length !== 10) {
+      if (celdas.length !== 12) {
         thead.html(encabezado);
       }
     }
@@ -647,6 +649,8 @@ $(document).ready(function() {
             SkuCharolas: row.SkuCharolas,
             DescripcionCharolas: row.DescripcionCharolas,
             Cantidad: row.Cantidad,
+            UsuarioCreador: row.UsuarioCreador || '',
+            FechaRegistro: row.FechaRegistro || '',
             STATUSID: row.STATUSID,
             Status: row.Status,
             Detalles: detalles,
@@ -663,6 +667,8 @@ $(document).ready(function() {
             SkuCharolas: row.SkuCharolas,
             DescripcionCharolas: row.DescripcionCharolas,
             Cantidad: row.Cantidad,
+            UsuarioCreador: datosDetalle.UsuarioCreador,
+            FechaRegistro: datosDetalle.FechaRegistro,
             STATUSID: row.STATUSID,
             Salida: datosDetalle.Salida,
             Entrada: datosDetalle.Entrada,
@@ -694,6 +700,18 @@ $(document).ready(function() {
             { data: 'SkuCharolas' },
             { data: 'DescripcionCharolas' },
             { data: 'Cantidad' },
+            {
+              data: 'UsuarioCreador',
+              render: function(data) {
+                return escapeHtml(data || '');
+              }
+            },
+            {
+              data: 'FechaRegistro',
+              render: function(data) {
+                return escapeHtml(data || '');
+              }
+            },
             {
               data: 'Salida',
               render: function(data) {

--- a/charolas.php
+++ b/charolas.php
@@ -140,6 +140,8 @@ if ($conn) {
                                             <th scope="col">SKU</th>
                                             <th scope="col">Descripción</th>
                                             <th scope="col">Cantidad</th>
+                                            <th scope="col">Usuario</th>
+                                            <th scope="col">Fecha creación</th>
                                             <th scope="col">Cambiar estatus</th>
                                         </tr>
                                     </thead>


### PR DESCRIPTION
### Motivation
- Record which user created an orden_charola and surface that information in the UI and exports to improve traceability.
- Avoid runtime errors when the new `USUARIOIDCreador` column is missing by creating it if absent and by conditionally joining data.

### Description
- Added `asegurarColumnaUsuarioCreador` to `ServerInfoOrdenesCharolas.php` and `ServerInsertarOrdenCharolas.php` to ensure the `USUARIOIDCreador` column exists and can be populated. 
- Added a reusable `columnaExiste` helper to check arbitrary column presence and used it to conditionally select `FechaRegistro` in `ServerInfoOrdenesCharolas.php` and to conditionally `LEFT JOIN usuarios` to resolve creator name. 
- Changed `ServerInsertarOrdenCharolas.php` to `session_start()` when needed, read `$_SESSION['USUARIOID']`, and include `USUARIOIDCreador` in `INSERT` statements when the column is available. 
- Updated UI code (`App/js/AppCharolas.js` and `charolas.php`) to add the new table columns "Usuario" and "Fecha creación", to map `UsuarioCreador` and `FechaRegistro` from the response into the DataTable, and to escape/render those fields for display and export.

### Testing
- Ran PHP syntax checks with `php -l` against the modified PHP files and they reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12a1888688327a338964386667fbc)