### PR TITLE
Agregar botón y flujo de cancelación de requisiciones de charolas (solo Soporte IT/Administrador)

### DIFF
--- a/App/Modales/ModalesCharolas.php
+++ b/App/Modales/ModalesCharolas.php
@@ -67,3 +67,29 @@
         </div>
     </div>
 </div>
+
+
+<div class="modal" id="ModalCancelarCharola">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Cancelar requisición</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="btn-close"></button>
+            </div>
+            <form id="FormCancelarCharola">
+                <div class="modal-body">
+                    <p class="mb-3">Indica el motivo de la cancelación para confirmar esta acción.</p>
+                    <div class="mb-3">
+                        <label for="MotivoCancelacionCharola" class="form-label">Motivo de cancelación</label>
+                        <textarea class="form-control" id="MotivoCancelacionCharola" name="MOTIVO_CANCELACION" rows="3" maxlength="500" required></textarea>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <input type="hidden" id="ORDENCHAROLAIDCancelar" name="ORDENCHAROLAID">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
+                    <button type="submit" class="btn btn-danger">Confirmar cancelación</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/App/Server/ServerInfoOrdenesCharolas.php
+++ b/App/Server/ServerInfoOrdenesCharolas.php
@@ -117,6 +117,25 @@ function asegurarColumnaFactura($conn)
     return $columnaFactura;
 }
 
+function asegurarColumnaMotivoCancelacion($conn)
+{
+    $columnaMotivoCancelacion = false;
+
+    $consulta = mysqli_query($conn, "SHOW COLUMNS FROM ordenes_charolas LIKE 'MotivoCancelacion'");
+    if ($consulta instanceof mysqli_result) {
+        $columnaMotivoCancelacion = mysqli_num_rows($consulta) > 0;
+        mysqli_free_result($consulta);
+    }
+
+    if (!$columnaMotivoCancelacion) {
+        if (mysqli_query($conn, 'ALTER TABLE ordenes_charolas ADD COLUMN `MotivoCancelacion` VARCHAR(500) NULL')) {
+            $columnaMotivoCancelacion = true;
+        }
+    }
+
+    return $columnaMotivoCancelacion;
+}
+
 function asegurarColumnaUsuarioCreador($conn)
 {
     $columnaUsuarioCreador = false;
@@ -209,13 +228,15 @@ if (!empty($seleccionAuditado)) {
 
 $columnaFacturaDisponible = asegurarColumnaFactura($conn);
 $seleccionFacturaSql = $columnaFacturaDisponible ? ', oc.Factura AS Factura' : ', NULL AS Factura';
+$columnaMotivoCancelacionDisponible = asegurarColumnaMotivoCancelacion($conn);
+$seleccionMotivoCancelacionSql = $columnaMotivoCancelacionDisponible ? ', oc.MotivoCancelacion AS MotivoCancelacion' : ', NULL AS MotivoCancelacion';
 $columnaUsuarioCreadorDisponible = asegurarColumnaUsuarioCreador($conn);
 $columnaFechaRegistroDisponible = columnaExiste($conn, 'ordenes_charolas', 'FechaRegistro');
 $seleccionUsuarioCreadorSql = $columnaUsuarioCreadorDisponible ? ", TRIM(CONCAT_WS(' ', u.PrimerNombre, u.ApellidoPaterno)) AS UsuarioCreador, oc.USUARIOIDCreador" : ", NULL AS UsuarioCreador, NULL AS USUARIOIDCreador";
 $seleccionFechaRegistroSql = $columnaFechaRegistroDisponible ? ", DATE_FORMAT(oc.FechaRegistro, '%Y-%m-%d %H:%i:%s') AS FechaRegistro" : ', NULL AS FechaRegistro';
 $joinUsuarioCreadorSql = $columnaUsuarioCreadorDisponible ? 'LEFT JOIN usuarios u ON u.USUARIOID = oc.USUARIOIDCreador' : '';
 
-$query = "SELECT oc.ORDENCHAROLAID, oc.CHAROLASID, oc.Cantidad, oc.STATUSID, s.Status, c.SkuCharolas, c.DescripcionCharolas" . $seleccionUsuarioCreadorSql . $seleccionFechaRegistroSql . $seleccionAuditadoSql . $seleccionFacturaSql . $columnasSeleccionadas . "
+$query = "SELECT oc.ORDENCHAROLAID, oc.CHAROLASID, oc.Cantidad, oc.STATUSID, s.Status, c.SkuCharolas, c.DescripcionCharolas" . $seleccionUsuarioCreadorSql . $seleccionFechaRegistroSql . $seleccionAuditadoSql . $seleccionFacturaSql . $seleccionMotivoCancelacionSql . $columnasSeleccionadas . "
           FROM ordenes_charolas oc
           JOIN charolas c ON c.CHAROLASID = oc.CHAROLASID
           JOIN status s ON s.STATUSID = oc.STATUSID
@@ -315,6 +336,7 @@ while ($row = mysqli_fetch_assoc($result)) {
     $row['Entrada'] = isset($row['Entrada']) ? trim((string) $row['Entrada']) : '';
     $row['Almacen'] = isset($row['Almacen']) ? trim((string) $row['Almacen']) : '';
     $row['Factura'] = isset($row['Factura']) ? trim((string) $row['Factura']) : '';
+    $row['MotivoCancelacion'] = isset($row['MotivoCancelacion']) ? trim((string) $row['MotivoCancelacion']) : '';
     $ordenes[] = $row;
 }
 mysqli_free_result($result);

--- a/App/Server/ServerUpdateOrdenCharolas.php
+++ b/App/Server/ServerUpdateOrdenCharolas.php
@@ -66,6 +66,25 @@ function asegurarColumnaFactura($conn)
     return $columnaFactura;
 }
 
+function asegurarColumnaMotivoCancelacion($conn)
+{
+    $columnaMotivoCancelacion = false;
+
+    $consulta = mysqli_query($conn, "SHOW COLUMNS FROM ordenes_charolas LIKE 'MotivoCancelacion'");
+    if ($consulta instanceof mysqli_result) {
+        $columnaMotivoCancelacion = mysqli_num_rows($consulta) > 0;
+        mysqli_free_result($consulta);
+    }
+
+    if (!$columnaMotivoCancelacion) {
+        if (mysqli_query($conn, 'ALTER TABLE ordenes_charolas ADD COLUMN `MotivoCancelacion` VARCHAR(500) NULL')) {
+            $columnaMotivoCancelacion = true;
+        }
+    }
+
+    return $columnaMotivoCancelacion;
+}
+
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     http_response_code(405);
     echo json_encode(['error' => 'Método no permitido.']);
@@ -92,6 +111,7 @@ $salida = $salidaDefinido ? trim((string) $_POST['SALIDA']) : null;
 $entrada = $entradaDefinido ? trim((string) $_POST['ENTRADA']) : null;
 $almacen = $almacenDefinido ? trim((string) $_POST['ALMACEN']) : null;
 $factura = isset($_POST['FACTURA']) ? trim((string) $_POST['FACTURA']) : '';
+$motivoCancelacion = isset($_POST['MOTIVO_CANCELACION']) ? trim((string) $_POST['MOTIVO_CANCELACION']) : '';
 
 if ($ordenCharolaId <= 0 || $statusIdEntrada === '') {
     http_response_code(400);
@@ -105,6 +125,8 @@ $tipoUsuarioActual = isset($_SESSION['TipoDeUsuario']) ? strtolower(trim((string
 $puedeCambiarEstatus = $tipoUsuarioActual !== '' && in_array($tipoUsuarioActual, $rolesPermitidos, true);
 $puedeAsignarVerificado = $puedeCambiarEstatus;
 $puedeAsignarAuditado = $tipoUsuarioActual === 'auditor';
+$rolesPermitidosCancelar = ['soporte it', 'administrador'];
+$puedeCancelar = $tipoUsuarioActual !== '' && in_array($tipoUsuarioActual, $rolesPermitidosCancelar, true);
 
 if (!$puedeCambiarEstatus) {
     http_response_code(403);
@@ -160,6 +182,9 @@ $puedePersistirCamposAuditado = !in_array(false, $columnasAuditado, true);
 $columnaFacturaDisponible = asegurarColumnaFactura($conn);
 $statusEnProcesoId = '2';
 $requiereFactura = $statusIdEntrada === $statusEnProcesoId;
+$statusCanceladoId = '5';
+$esCancelacion = $statusIdEntrada === $statusCanceladoId;
+$columnaMotivoCancelacionDisponible = $esCancelacion ? asegurarColumnaMotivoCancelacion($conn) : false;
 
 if ($requiereCamposAuditado && !$puedePersistirCamposAuditado) {
     http_response_code(500);
@@ -175,6 +200,31 @@ if ($requiereCamposAuditado) {
         mysqli_close($conn);
         exit;
     }
+}
+
+if ($esCancelacion && !$puedeCancelar) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Solo un Soporte IT o administrador puede cancelar requisiciones.']);
+    mysqli_close($conn);
+    exit;
+}
+
+if ($esCancelacion && !$columnaMotivoCancelacionDisponible) {
+    http_response_code(500);
+    echo json_encode(['error' => 'No se pudo habilitar el motivo de cancelación en la base de datos.']);
+    mysqli_close($conn);
+    exit;
+}
+
+if ($esCancelacion && $motivoCancelacion === '') {
+    http_response_code(400);
+    echo json_encode(['error' => 'El motivo de cancelación es obligatorio.']);
+    mysqli_close($conn);
+    exit;
+}
+
+if ($esCancelacion && strlen($motivoCancelacion) > 500) {
+    $motivoCancelacion = substr($motivoCancelacion, 0, 500);
 }
 
 if ($requiereFactura && $factura === '') {
@@ -232,6 +282,12 @@ if ($requiereCamposAuditado) {
     }
 }
 
+if ($esCancelacion && $columnaMotivoCancelacionDisponible) {
+    $camposActualizar[] = 'MotivoCancelacion = ?';
+    $tipos .= 's';
+    $valores[] = $motivoCancelacion;
+}
+
 if ($columnaFacturaDisponible) {
     if ($factura !== '') {
         $camposActualizar[] = 'Factura = ?';
@@ -273,7 +329,8 @@ echo json_encode([
     'Salida' => $requiereCamposAuditado && $puedePersistirCamposAuditado ? $salida : '',
     'Entrada' => $requiereCamposAuditado && $puedePersistirCamposAuditado ? $entrada : '',
     'Almacen' => $requiereCamposAuditado && $puedePersistirCamposAuditado ? $almacen : '',
-    'Factura' => $columnaFacturaDisponible ? $factura : ''
+    'Factura' => $columnaFacturaDisponible ? $factura : '',
+    'MotivoCancelacion' => $esCancelacion && $columnaMotivoCancelacionDisponible ? $motivoCancelacion : ''
 ]);
 
 mysqli_close($conn);

--- a/App/js/AppCharolas.js
+++ b/App/js/AppCharolas.js
@@ -30,6 +30,10 @@ $(document).ready(function() {
   var mensajeRestriccionAuditado = typeof configuracionCharolas.mensajeRestriccionAuditado === 'string' && configuracionCharolas.mensajeRestriccionAuditado.trim() !== ''
     ? configuracionCharolas.mensajeRestriccionAuditado
     : 'Solo un auditor puede asignar el estatus Auditado.';
+  var puedeCancelar = !!configuracionCharolas.puedeCancelar;
+  var mensajeRestriccionCancelar = typeof configuracionCharolas.mensajeRestriccionCancelar === 'string' && configuracionCharolas.mensajeRestriccionCancelar.trim() !== ''
+    ? configuracionCharolas.mensajeRestriccionCancelar
+    : 'Solo un Soporte IT o administrador puede cancelar requisiciones.';
   var nombreStatusAuditadoNormalizado = '';
   var $camposAuditado = $('#CamposAuditado');
   var $salidaAuditado = $('#SalidaAuditado');
@@ -44,6 +48,11 @@ $(document).ready(function() {
   var $btnConfirmarCambioStatus = $('#BtnConfirmarCambioStatus');
   var $btnGenerarRequisicion = $('#GenerarRequisicionBtn');
   var statusEnProcesoId = '2';
+  var statusCanceladoId = '5';
+  var $modalCancelarCharola = $('#ModalCancelarCharola');
+  var $formCancelarCharola = $('#FormCancelarCharola');
+  var $ordenCharolaIdCancelar = $('#ORDENCHAROLAIDCancelar');
+  var $motivoCancelacionCharola = $('#MotivoCancelacionCharola');
 
   function mostrarBotonGenerarRequisicion() {
     if ($btnGenerarRequisicion.length) {
@@ -359,6 +368,14 @@ $(document).ready(function() {
     }
   }
 
+  function construirBotonCancelar(data) {
+    if (!puedeCancelar || !data || String(data.STATUSID || '') === statusCanceladoId) {
+      return '';
+    }
+
+    return '<div class="mt-3"><button type="button" class="btn btn-outline-danger btn-sm btn-cancelar-charola" data-order="' + escapeHtml(data.ORDENCHAROLAID) + '">Cancelar requisición</button></div>';
+  }
+
   function calcularTotalesMateriales(detalles) {
     var totales = {
       Largueros: 0,
@@ -483,8 +500,12 @@ $(document).ready(function() {
   }
 
   function construirDetalleRequisicion(data) {
-    if (!data || !Array.isArray(data.Detalles) || !data.Detalles.length) {
-      return '<div class="text-muted">Sin materiales registrados para esta requisición.</div>';
+    if (!data) {
+      return '<div class="text-muted">Sin información registrada para esta requisición.</div>';
+    }
+
+    if (!Array.isArray(data.Detalles) || !data.Detalles.length) {
+      return '<div class="detalle-requisicion d-flex flex-column flex-md-row justify-content-between gap-3"><div class="text-muted">Sin materiales registrados para esta requisición.</div>' + construirBotonCancelar(data) + '</div>';
     }
 
     var totalLargueros = renderMaterial(data, 'Largueros');
@@ -494,6 +515,10 @@ $(document).ready(function() {
     var salida = data.Salida ? data.Salida : '—';
     var entrada = data.Entrada ? data.Entrada : '—';
     var almacen = data.Almacen ? data.Almacen : '—';
+    var motivoCancelacion = data.MotivoCancelacion ? data.MotivoCancelacion : '—';
+    var bloqueMotivoCancelacion = String(data.STATUSID || '') === statusCanceladoId || data.MotivoCancelacion
+      ? '<div class="col-sm-12 col-lg-6"><div class="text-muted text-uppercase small">Motivo cancelación</div><div class="fw-semibold">' + escapeHtml(motivoCancelacion) + '</div></div>'
+      : '';
 
     var html = '<div class="detalle-requisicion">';
 
@@ -502,10 +527,11 @@ $(document).ready(function() {
       '<div class="col-sm-6 col-lg-3"><div class="text-muted text-uppercase small">SKU</div><div class="fw-semibold">' + escapeHtml(data.SkuCharolas) + '</div></div>' +
       '<div class="col-sm-12 col-lg-6"><div class="text-muted text-uppercase small">Descripción</div><div class="fw-semibold">' + escapeHtml(data.DescripcionCharolas) + '</div></div>' +
       '<div class="col-sm-6 col-lg-3"><div class="text-muted text-uppercase small">Cantidad</div><div class="fw-semibold">' + escapeHtml(data.Cantidad) + '</div></div>' +
-      '<div class="col-sm-6 col-lg-3"><div class="text-muted text-uppercase small">Estatus</div><div class="fw-semibold">' + escapeHtml(obtenerNombreStatus(data.Status, data.STATUSID)) + '</div></div>' +
+      '<div class="col-sm-6 col-lg-3 ms-lg-auto"><div class="text-muted text-uppercase small">Estatus</div><div class="fw-semibold">' + escapeHtml(obtenerNombreStatus(data.Status, data.STATUSID)) + '</div>' + construirBotonCancelar(data) + '</div>' +
       '<div class="col-sm-6 col-lg-3"><div class="text-muted text-uppercase small">Salida</div><div class="fw-semibold">' + escapeHtml(salida) + '</div></div>' +
       '<div class="col-sm-6 col-lg-3"><div class="text-muted text-uppercase small">Entrada</div><div class="fw-semibold">' + escapeHtml(entrada) + '</div></div>' +
       '<div class="col-sm-6 col-lg-3"><div class="text-muted text-uppercase small">Almacén</div><div class="fw-semibold">' + escapeHtml(almacen) + '</div></div>' +
+      bloqueMotivoCancelacion +
     '</div>';
 
     html += '<div class="row g-3 detalle-requisicion__totales mt-2">' +
@@ -658,6 +684,7 @@ $(document).ready(function() {
             Entrada: typeof row.Entrada === 'string' ? row.Entrada : '',
             Almacen: typeof row.Almacen === 'string' ? row.Almacen : '',
             Factura: typeof row.Factura === 'string' ? row.Factura : '',
+            MotivoCancelacion: typeof row.MotivoCancelacion === 'string' ? row.MotivoCancelacion : '',
             _totalesMateriales: normalizarTotalesMateriales(totales)
           };
 
@@ -887,6 +914,79 @@ $(document).ready(function() {
         }
       });
     }
+  });
+
+
+  $('#TablaOrdenesCharolas').on('click', '.btn-cancelar-charola', function() {
+    if (!puedeCancelar) {
+      window.alert(mensajeRestriccionCancelar);
+      return;
+    }
+
+    var orderId = $(this).data('order');
+    $ordenCharolaIdCancelar.val(orderId !== undefined && orderId !== null ? String(orderId) : '');
+    $motivoCancelacionCharola.val('');
+    $modalCancelarCharola.modal('show');
+  });
+
+  $formCancelarCharola.on('submit', function(e) {
+    e.preventDefault();
+
+    if (!puedeCancelar) {
+      window.alert(mensajeRestriccionCancelar);
+      $modalCancelarCharola.modal('hide');
+      return;
+    }
+
+    var orderId = $ordenCharolaIdCancelar.val();
+    var motivo = ($motivoCancelacionCharola.val() || '').trim();
+
+    if (!orderId) {
+      $modalCancelarCharola.modal('hide');
+      return;
+    }
+
+    if (!motivo) {
+      window.alert('Debes capturar el motivo de cancelación.');
+      return;
+    }
+
+    if (motivo.length > 500) {
+      motivo = motivo.slice(0, 500);
+    }
+
+    $.ajax({
+      type: 'POST',
+      url: 'App/Server/ServerUpdateOrdenCharolas.php',
+      data: {
+        ORDENCHAROLAID: orderId,
+        STATUSID: statusCanceladoId,
+        MOTIVO_CANCELACION: motivo
+      },
+      dataType: 'json',
+      success: function(response) {
+        if (response && response.error) {
+          window.alert(response.error);
+          return;
+        }
+        $modalCancelarCharola.modal('hide');
+        cargarOrdenes();
+      },
+      error: function(xhr) {
+        var mensaje = 'No se pudo cancelar la requisición.';
+        if (xhr && xhr.responseJSON && xhr.responseJSON.error) {
+          mensaje = xhr.responseJSON.error;
+        }
+        window.alert(mensaje);
+      }
+    });
+  });
+
+  $modalCancelarCharola.on('hidden.bs.modal', function() {
+    if ($formCancelarCharola[0]) {
+      $formCancelarCharola[0].reset();
+    }
+    $ordenCharolaIdCancelar.val('');
   });
 
   $('#TablaOrdenesCharolas').on('click', '.badge-status', function() {

--- a/charolas.php
+++ b/charolas.php
@@ -30,8 +30,10 @@ $statusVerificadoNombre = 'Verificado';
 $statusVerificadoId = null;
 $mensajeRestriccionVerificado = 'Solo un Soporte IT, administrador, supervisor o auditor puede asignar el estatus Verificado.';
 $tiposPermitidosCambioEstatus = ['soporte it', 'administrador', 'supervisor', 'auditor'];
+$tiposPermitidosCancelar = ['soporte it', 'administrador'];
 $tipoUsuarioActual = isset($_SESSION['TipoDeUsuario']) ? strtolower(trim((string) $_SESSION['TipoDeUsuario'])) : '';
 $puedeCambiarEstatusCharolas = $tipoUsuarioActual !== '' && in_array($tipoUsuarioActual, $tiposPermitidosCambioEstatus, true);
+$puedeCancelarCharolas = $tipoUsuarioActual !== '' && in_array($tipoUsuarioActual, $tiposPermitidosCancelar, true);
 $puedeAsignarVerificado = $puedeCambiarEstatusCharolas;
 $statusAuditadoNombre = 'Auditado';
 $statusAuditadoId = null;
@@ -168,6 +170,8 @@ if ($conn) {
             'nombreStatusAuditado' => $statusAuditadoNombre,
             'puedeAsignarAuditado' => $puedeAsignarAuditado,
             'mensajeRestriccionAuditado' => $mensajeRestriccionAuditado,
+            'puedeCancelar' => $puedeCancelarCharolas,
+            'mensajeRestriccionCancelar' => 'Solo un Soporte IT o administrador puede cancelar requisiciones.',
         ], JSON_UNESCAPED_UNICODE); ?>;
     </script>
 


### PR DESCRIPTION
### Motivation
- Permitir cancelar una requisición de armado desde la vista de detalles, pero solo para perfiles con permiso de Soporte IT o Administrador. 
- Registrar y mostrar el motivo de la cancelación para trazabilidad.

### Description
- Expongo un nuevo flag y mensaje al frontend en `charolas.php` mediante `window.charolasConfig` (`puedeCancelar` y `mensajeRestriccionCancelar`).
- Agrego un botón `Cancelar requisición` dentro del detalle expandido de cada requisición (lado derecho, junto a `Estatus`) que se renderiza solo si el usuario tiene permiso y la orden no está ya cancelada (cambios en `App/js/AppCharolas.js`).
- Añadí un modal en `App/Modales/ModalesCharolas.php` con un `textarea` para capturar el motivo, botón `Confirmar cancelación` y `Cerrar` para abortar.
- Implementé el flujo JS para abrir el modal, validar motivo obligatorio, enviar `POST` a `App/Server/ServerUpdateOrdenCharolas.php` con `STATUSID = 5` y `MOTIVO_CANCELACION`, y recargar la tabla tras éxito (en `App/js/AppCharolas.js`).
- En el servidor (`App/Server/ServerUpdateOrdenCharolas.php`) agregué: validación de permiso (solo `soporte it` y `administrador` pueden cancelar), validación del motivo (obligatorio, tope 500 chars), creación automática de la columna `MotivoCancelacion` si falta, y persistencia del campo en la actualización de la orden.
- En `App/Server/ServerInfoOrdenesCharolas.php` añadí lectura/creación de la columna `MotivoCancelacion` y devuelvo `MotivoCancelacion` en la API para que se muestre dentro del detalle.

### Testing
- Ejecuté `php -l charolas.php` — OK.
- Ejecuté `php -l App/Modales/ModalesCharolas.php` — OK.
- Ejecuté `php -l App/Server/ServerUpdateOrdenCharolas.php` — OK.
- Ejecuté `php -l App/Server/ServerInfoOrdenesCharolas.php` — OK.
- Ejecuté `node --check App/js/AppCharolas.js` — OK.
- Ejecuté `git diff --check` — OK.
- Intenté `npx playwright --version` para captura visual pero la instalación falló por políticas del registro npm (`403 Forbidden`), por lo que no se generó screenshot de la UI en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff6f7001d883278a750d23e76a212e)