### PR TITLE
Add solicitudes (client/product requests) for Material Pendiente with UI, server, DB, and notifications

### DIFF
--- a/App/Modales/ModalesMaterialPendiente.php
+++ b/App/Modales/ModalesMaterialPendiente.php
@@ -153,22 +153,22 @@
                                         <?php if (!$hayProductosPendientes) : ?>
                                             <div class="col-12">
                                                 <div class="alert alert-warning" role="alert">
-                                                    No se encontraron productos activos para seleccionar. Agrega productos en el catálogo para poder registrar partidas pendientes.
+                                                    No se encontraron productos activos para seleccionar. Puedes usar la opción "Solicitar" para capturar el SKU pendiente.
                                                 </div>
                                             </div>
                                         <?php endif; ?>
                                         <div class="col-12">
-                                            <div id="ProductosPendientesContainer" class="productos-pendientes-container" data-productos-disponibles="<?php echo $hayProductosPendientes ? '1' : '0'; ?>">
+                                            <div id="ProductosPendientesContainer" class="productos-pendientes-container" data-productos-disponibles="1">
                                                 <div class="row align-items-end">
                                                     <div class="col-lg-8 col-sm-12 mb-4" id="ProductoPendienteSelectContainer">
                                                         <label for="ProductoPendienteSelect" class="form-label">Producto pendiente</label>
-                                                        <select class="form-select select2-producto" id="ProductoPendienteSelect" data-placeholder="Selecciona producto" data-search-url="App/Server/ServerBuscarProductosMaterialPendiente.php" <?php echo $hayProductosPendientes ? '' : 'disabled'; ?> required>
+                                                        <select class="form-select select2-producto" id="ProductoPendienteSelect" data-placeholder="Selecciona producto" data-search-url="App/Server/ServerBuscarProductosMaterialPendiente.php" required>
                                                             <?php echo $opcionesProductosPendientes; ?>
                                                         </select>
                                                     </div>
                                                     <div class="col-lg-4 col-sm-12 mb-4" id="CantidadPendienteContainer">
                                                         <label for="CantidadPendiente" class="form-label">Cantidad pendiente</label>
-                                                        <input type="number" class="form-control" id="CantidadPendiente" min="1" step="1" <?php echo $hayProductosPendientes ? '' : 'disabled'; ?> required>
+                                                        <input type="number" class="form-control" id="CantidadPendiente" min="1" step="1" required>
                                                     </div>
                                                     <div class="col-12 mb-2">
                                                         <div class="form-check">
@@ -230,7 +230,7 @@
                 </div>
                 <div class="modal-footer modal-pendiente-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
-                    <button type="submit" class="btn btn-primary" id="BtnGuardarPendiente" <?php echo $hayProductosPendientes ? '' : 'disabled'; ?>>Guardar</button>
+                    <button type="submit" class="btn btn-primary" id="BtnGuardarPendiente">Guardar</button>
                 </div>
             </form>
         </div>

--- a/App/Server/ServerActualizarMaterialPendiente.php
+++ b/App/Server/ServerActualizarMaterialPendiente.php
@@ -121,8 +121,16 @@ if (!asegurarTablaMaterialPendiente($conn, $nombreBaseDatos)) {
     responderError('No se pudo preparar la tabla de material pendiente. Intenta nuevamente.');
 }
 
+asegurarTablasSolicitudes($conn);
+
 if (!asegurarTablaFacturaMP($conn, $nombreBaseDatos)) {
     responderError('No se pudo preparar la tabla de facturas de material pendiente. Intenta nuevamente.');
+}
+
+function asegurarTablasSolicitudes(mysqli $conn): void
+{
+    @mysqli_query($conn, "CREATE TABLE IF NOT EXISTS Solicitud_Clientes (SolicitudClienteID INT NOT NULL AUTO_INCREMENT, NumeroCliente VARCHAR(100) NOT NULL, Atendida TINYINT(1) NOT NULL DEFAULT 0, FechaSolicitud TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, FechaAtencion TIMESTAMP NULL DEFAULT NULL, PRIMARY KEY (SolicitudClienteID), INDEX idx_solicitud_cliente_estado (Atendida), INDEX idx_solicitud_cliente_numero (NumeroCliente)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+    @mysqli_query($conn, "CREATE TABLE IF NOT EXISTS Solicitud_Productos (SolicitudProductoID INT NOT NULL AUTO_INCREMENT, SKU VARCHAR(100) NOT NULL, Atendida TINYINT(1) NOT NULL DEFAULT 0, FechaSolicitud TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, FechaAtencion TIMESTAMP NULL DEFAULT NULL, PRIMARY KEY (SolicitudProductoID), INDEX idx_solicitud_producto_estado (Atendida), INDEX idx_solicitud_producto_sku (SKU)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
 }
 
 function obtenerTextoCatalogo(mysqli $conn, string $tabla, string $columnaId, string $columnaTexto, int $id): string
@@ -268,6 +276,7 @@ if ($surtidorValor !== '' && ctype_digit($surtidorValor)) {
 }
 
 $productosValidos = [];
+$skusSolicitados = [];
 foreach ($productos as $producto) {
     if (!is_array($producto)) {
         continue;
@@ -286,6 +295,10 @@ foreach ($productos as $producto) {
         'descripcion' => $descripcion,
         'cantidad' => $cantidad
     ];
+
+    if (isset($producto['solicitado']) && (string) $producto['solicitado'] === '1') {
+        $skusSolicitados[$sku] = true;
+    }
 }
 
 if (empty($productosValidos)) {
@@ -380,6 +393,26 @@ foreach ($productosValidos as $producto) {
 
 mysqli_stmt_close($stmtInsertar);
 
+if ($usarOtraRazonSocial && $numeroClienteManual !== '') {
+    $stmtSolicitudCliente = mysqli_prepare($conn, 'INSERT INTO Solicitud_Clientes (NumeroCliente) VALUES (?)');
+    if ($stmtSolicitudCliente) {
+        mysqli_stmt_bind_param($stmtSolicitudCliente, 's', $numeroClienteManual);
+        mysqli_stmt_execute($stmtSolicitudCliente);
+        mysqli_stmt_close($stmtSolicitudCliente);
+    }
+}
+
+if (!empty($skusSolicitados)) {
+    $stmtSolicitudProducto = mysqli_prepare($conn, 'INSERT INTO Solicitud_Productos (SKU) VALUES (?)');
+    if ($stmtSolicitudProducto) {
+        foreach (array_keys($skusSolicitados) as $skuSolicitado) {
+            mysqli_stmt_bind_param($stmtSolicitudProducto, 's', $skuSolicitado);
+            mysqli_stmt_execute($stmtSolicitudProducto);
+        }
+        mysqli_stmt_close($stmtSolicitudProducto);
+    }
+}
+
 if ($documentoAnterior !== $numeroFactura) {
     $stmtActualizarDocumento = mysqli_prepare(
         $conn,
@@ -394,6 +427,20 @@ if ($documentoAnterior !== $numeroFactura) {
 }
 
 mysqli_commit($conn);
+
+$clientesSolicitadosNotificacion = ($usarOtraRazonSocial && $numeroClienteManual !== '') ? [$numeroClienteManual] : [];
+$productosSolicitadosNotificacion = array_keys($skusSolicitados);
+
+if (!empty($clientesSolicitadosNotificacion) || !empty($productosSolicitadosNotificacion)) {
+    include_once __DIR__ . '/../../includes/MandarEmail.php';
+    if (function_exists('EnviarNotificacionSolicitudMaterialPendiente')) {
+        EnviarNotificacionSolicitudMaterialPendiente(
+            $clientesSolicitadosNotificacion,
+            $productosSolicitadosNotificacion,
+            $numeroFactura
+        );
+    }
+}
 
 echo json_encode([
     'success' => true,

--- a/App/Server/ServerInsertarClientes.php
+++ b/App/Server/ServerInsertarClientes.php
@@ -34,6 +34,24 @@ if (!mysqli_query($conn, $sql)) {
 
 $last_id = mysqli_insert_id($conn);
 
+$nombreClienteLimpio = trim((string) ($_POST['NombreCliente'] ?? ''));
+foreach ([$clienteSianInput, $clcSianInput] as $numeroSolicitud) {
+    if ($numeroSolicitud === '') {
+        continue;
+    }
+
+    @mysqli_query($conn, "CREATE TABLE IF NOT EXISTS Solicitud_Clientes (SolicitudClienteID INT NOT NULL AUTO_INCREMENT, NumeroCliente VARCHAR(100) NOT NULL, Atendida TINYINT(1) NOT NULL DEFAULT 0, FechaSolicitud TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, FechaAtencion TIMESTAMP NULL DEFAULT NULL, PRIMARY KEY (SolicitudClienteID), INDEX idx_solicitud_cliente_estado (Atendida), INDEX idx_solicitud_cliente_numero (NumeroCliente)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+    $numeroEscapado = mysqli_real_escape_string($conn, $numeroSolicitud);
+    @mysqli_query($conn, "UPDATE Solicitud_Clientes SET Atendida = 1, FechaAtencion = NOW() WHERE NumeroCliente = '$numeroEscapado' AND Atendida = 0");
+
+    if ($nombreClienteLimpio !== '') {
+        $nombreEscapado = mysqli_real_escape_string($conn, $nombreClienteLimpio);
+        @mysqli_query($conn, "UPDATE facturamp SET RazonSocialFMP = '$nombreEscapado', ClienteFMP = '$nombreEscapado' WHERE RazonSocialFMP LIKE '%Cliente #$numeroEscapado%'");
+        @mysqli_query($conn, "UPDATE materialpendiente SET RazonSocialMP = '$nombreEscapado', ClienteMP = '$nombreEscapado' WHERE RazonSocialMP LIKE '%Cliente #$numeroEscapado%'");
+    }
+}
+
 $msg = array('CLIENTEID' => $last_id);
 
 echo json_encode($msg);

--- a/App/Server/ServerInsertarMaterialPendiente.php
+++ b/App/Server/ServerInsertarMaterialPendiente.php
@@ -115,6 +115,27 @@ function asegurarTablaFacturaMP(mysqli $conn, string $baseDatos): bool
     return $resultado;
 }
 
+function asegurarTablasSolicitudes(mysqli $conn): void
+{
+    @mysqli_query($conn, "CREATE TABLE IF NOT EXISTS Solicitud_Clientes (
+        SolicitudClienteID INT NOT NULL AUTO_INCREMENT,
+        NumeroCliente VARCHAR(100) NOT NULL,
+        Atendida TINYINT(1) NOT NULL DEFAULT 0,
+        FechaSolicitud TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FechaAtencion TIMESTAMP NULL DEFAULT NULL,
+        PRIMARY KEY (SolicitudClienteID), INDEX idx_solicitud_cliente_estado (Atendida), INDEX idx_solicitud_cliente_numero (NumeroCliente)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+    @mysqli_query($conn, "CREATE TABLE IF NOT EXISTS Solicitud_Productos (
+        SolicitudProductoID INT NOT NULL AUTO_INCREMENT,
+        SKU VARCHAR(100) NOT NULL,
+        Atendida TINYINT(1) NOT NULL DEFAULT 0,
+        FechaSolicitud TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FechaAtencion TIMESTAMP NULL DEFAULT NULL,
+        PRIMARY KEY (SolicitudProductoID), INDEX idx_solicitud_producto_estado (Atendida), INDEX idx_solicitud_producto_sku (SKU)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+}
+
 $nombreBaseDatos = $dbname ?? '';
 
 if (!asegurarTablaMaterialPendiente($conn, $nombreBaseDatos)) {
@@ -124,6 +145,8 @@ if (!asegurarTablaMaterialPendiente($conn, $nombreBaseDatos)) {
 if (!asegurarTablaFacturaMP($conn, $nombreBaseDatos)) {
     responderError('No se pudo preparar la tabla de facturas de material pendiente. Intenta nuevamente.');
 }
+
+asegurarTablasSolicitudes($conn);
 
 function obtenerTextoCatalogo(mysqli $conn, string $tabla, string $columnaId, string $columnaTexto, int $id): string
 {
@@ -241,6 +264,7 @@ if ($surtidorValor !== '' && ctype_digit($surtidorValor)) {
 }
 
 $productosValidos = [];
+$skusSolicitados = [];
 foreach ($productos as $producto) {
     if (!is_array($producto)) {
         continue;
@@ -259,6 +283,10 @@ foreach ($productos as $producto) {
         'descripcion' => $descripcion,
         'cantidad' => $cantidad
     ];
+
+    if (isset($producto['solicitado']) && (string) $producto['solicitado'] === '1') {
+        $skusSolicitados[$sku] = true;
+    }
 }
 
 if (empty($productosValidos)) {
@@ -356,7 +384,41 @@ foreach ($productosValidos as $producto) {
 }
 
 mysqli_stmt_close($stmt);
+
+if ($usarOtraRazonSocial && $numeroClienteManual !== '') {
+    $stmtSolicitudCliente = mysqli_prepare($conn, 'INSERT INTO Solicitud_Clientes (NumeroCliente) VALUES (?)');
+    if ($stmtSolicitudCliente) {
+        mysqli_stmt_bind_param($stmtSolicitudCliente, 's', $numeroClienteManual);
+        mysqli_stmt_execute($stmtSolicitudCliente);
+        mysqli_stmt_close($stmtSolicitudCliente);
+    }
+}
+
+if (!empty($skusSolicitados)) {
+    $stmtSolicitudProducto = mysqli_prepare($conn, 'INSERT INTO Solicitud_Productos (SKU) VALUES (?)');
+    if ($stmtSolicitudProducto) {
+        foreach (array_keys($skusSolicitados) as $skuSolicitado) {
+            mysqli_stmt_bind_param($stmtSolicitudProducto, 's', $skuSolicitado);
+            mysqli_stmt_execute($stmtSolicitudProducto);
+        }
+        mysqli_stmt_close($stmtSolicitudProducto);
+    }
+}
 mysqli_commit($conn);
+
+$clientesSolicitadosNotificacion = ($usarOtraRazonSocial && $numeroClienteManual !== '') ? [$numeroClienteManual] : [];
+$productosSolicitadosNotificacion = array_keys($skusSolicitados);
+
+if (!empty($clientesSolicitadosNotificacion) || !empty($productosSolicitadosNotificacion)) {
+    include_once __DIR__ . '/../../includes/MandarEmail.php';
+    if (function_exists('EnviarNotificacionSolicitudMaterialPendiente')) {
+        EnviarNotificacionSolicitudMaterialPendiente(
+            $clientesSolicitadosNotificacion,
+            $productosSolicitadosNotificacion,
+            $numeroFactura
+        );
+    }
+}
 
 echo json_encode([
     'success' => true,

--- a/App/Server/ServerInsertarProductos.php
+++ b/App/Server/ServerInsertarProductos.php
@@ -29,6 +29,13 @@ if (!mysqli_query($conn, $sql)) {
 
 $lastId = mysqli_insert_id($conn);
 
+@mysqli_query($conn, "CREATE TABLE IF NOT EXISTS Solicitud_Productos (SolicitudProductoID INT NOT NULL AUTO_INCREMENT, SKU VARCHAR(100) NOT NULL, Atendida TINYINT(1) NOT NULL DEFAULT 0, FechaSolicitud TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, FechaAtencion TIMESTAMP NULL DEFAULT NULL, PRIMARY KEY (SolicitudProductoID), INDEX idx_solicitud_producto_estado (Atendida), INDEX idx_solicitud_producto_sku (SKU)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+$skuEscapadoActualizar = mysqli_real_escape_string($conn, $sku);
+$descripcionEscapadaActualizar = mysqli_real_escape_string($conn, $descripcion !== '' ? $descripcion : 'SOLICITADO');
+@mysqli_query($conn, "UPDATE Solicitud_Productos SET Atendida = 1, FechaAtencion = NOW() WHERE SKU = '$skuEscapadoActualizar' AND Atendida = 0");
+@mysqli_query($conn, "UPDATE materialpendiente SET DescripcionMP = '$descripcionEscapadaActualizar' WHERE SkuMP = '$skuEscapadoActualizar' AND DescripcionMP = 'SOLICITADO'");
+
 echo json_encode(array('PRODUCTOSID' => $lastId));
 
 mysqli_close($conn);

--- a/App/Server/ServerSolicitudesMaterialPendiente.php
+++ b/App/Server/ServerSolicitudesMaterialPendiente.php
@@ -1,0 +1,33 @@
+<?php
+include("../../Connections/ConDB.php");
+header('Content-Type: application/json');
+
+function responder($data, int $code = 200): void { http_response_code($code); echo json_encode($data); exit; }
+function asegurar(mysqli $conn): void {
+    @mysqli_query($conn, "CREATE TABLE IF NOT EXISTS Solicitud_Clientes (
+        SolicitudClienteID INT NOT NULL AUTO_INCREMENT,
+        NumeroCliente VARCHAR(100) NOT NULL,
+        Atendida TINYINT(1) NOT NULL DEFAULT 0,
+        FechaSolicitud TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FechaAtencion TIMESTAMP NULL DEFAULT NULL,
+        PRIMARY KEY (SolicitudClienteID), INDEX idx_solicitud_cliente_estado (Atendida), INDEX idx_solicitud_cliente_numero (NumeroCliente)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+    @mysqli_query($conn, "CREATE TABLE IF NOT EXISTS Solicitud_Productos (
+        SolicitudProductoID INT NOT NULL AUTO_INCREMENT,
+        SKU VARCHAR(100) NOT NULL,
+        Atendida TINYINT(1) NOT NULL DEFAULT 0,
+        FechaSolicitud TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FechaAtencion TIMESTAMP NULL DEFAULT NULL,
+        PRIMARY KEY (SolicitudProductoID), INDEX idx_solicitud_producto_estado (Atendida), INDEX idx_solicitud_producto_sku (SKU)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+}
+if (!$conn) responder(['success'=>false,'message'=>'No se pudo conectar a la base de datos.'],500);
+asegurar($conn);
+$tipo = strtolower(trim($_GET['tipo'] ?? $_POST['tipo'] ?? ''));
+if ($tipo === 'clientes') {
+    $rs = mysqli_query($conn, "SELECT SolicitudClienteID id, NumeroCliente valor, FechaSolicitud fecha FROM Solicitud_Clientes WHERE Atendida = 0 ORDER BY SolicitudClienteID DESC");
+} elseif ($tipo === 'productos') {
+    $rs = mysqli_query($conn, "SELECT SolicitudProductoID id, SKU valor, FechaSolicitud fecha FROM Solicitud_Productos WHERE Atendida = 0 ORDER BY SolicitudProductoID DESC");
+} else responder(['success'=>false,'message'=>'Tipo de solicitud inválido.'],400);
+$records=[]; if ($rs instanceof mysqli_result) { while($r=mysqli_fetch_assoc($rs)) $records[]=$r; }
+responder(['success'=>true,'records'=>$records]);

--- a/App/js/AppMaterialPendiente.js
+++ b/App/js/AppMaterialPendiente.js
@@ -50,6 +50,9 @@ $(document).ready(function() {
   var $btnPaginaSiguiente = $('#MaterialPendientePaginaSiguiente');
   var $btnVerEliminados = $('#BtnVerEliminadosMaterialPendiente');
   var $modalEliminados = $('#ModalMaterialPendienteEliminado');
+  var $modalSolicitudes = $('#ModalSolicitudesMP');
+  var $modalAgregarClientes = $('#ModalAgregarClientes');
+  var $modalAgregarProductos = $('#ModalAgregarProductos');
   var $tablaEliminadosBody = $('#TablaMaterialPendienteEliminadoBody');
   var $errorEliminados = $('#MaterialPendienteEliminadoError');
   var REGISTROS_POR_PAGINA = 5;
@@ -78,9 +81,26 @@ $(document).ready(function() {
   var partidasPendientes = [];
   var modoEdicion = false;
   var instanciaModalEliminados = null;
+  var instanciaModalSolicitudes = null;
+  var instanciaModalAgregarClientes = null;
+  var instanciaModalAgregarProductos = null;
+  var tipoSolicitudActual = '';
+  var valorSolicitudActual = '';
 
   if ($modalEliminados.length && $modalEliminados.parent()[0] !== document.body) {
     $modalEliminados.appendTo('body');
+  }
+
+  if ($modalSolicitudes.length && $modalSolicitudes.parent()[0] !== document.body) {
+    $modalSolicitudes.appendTo('body');
+  }
+
+  if ($modalAgregarClientes.length && $modalAgregarClientes.parent()[0] !== document.body) {
+    $modalAgregarClientes.appendTo('body');
+  }
+
+  if ($modalAgregarProductos.length && $modalAgregarProductos.parent()[0] !== document.body) {
+    $modalAgregarProductos.appendTo('body');
   }
 
   function desplazarASeccionEntrega() {
@@ -243,6 +263,14 @@ $(document).ready(function() {
             });
           }
 
+          resultados.unshift({
+            id: 'solicitar:' + (params.term || ''),
+            text: 'Solicitar',
+            sku: (params.term || '').toString().trim(),
+            descripcion: 'SOLICITADO',
+            solicitado: true
+          });
+
           return {
             results: resultados,
             pagination: {
@@ -280,7 +308,14 @@ $(document).ready(function() {
       width: '100%',
       minimumResultsForSearch: 0,
       minimumInputLength: 2,
-      language: obtenerConfiguracionIdiomaMinimo()
+      language: obtenerConfiguracionIdiomaMinimo(),
+      tags: true,
+      createTag: function(params) {
+        var term = $.trim(params.term || '');
+        if (term === '') { return null; }
+        return { id: 'solicitar:' + term, text: 'Solicitar', numeroCliente: term, solicitado: true };
+      },
+      insertTag: function(data, tag) { data.unshift(tag); }
     });
   }
 
@@ -500,6 +535,7 @@ $(document).ready(function() {
       $celdaSku.append($('<input>', { type: 'hidden', name: 'productos[' + indice + '][descripcion]', value: partida.descripcion || '' }));
       $celdaSku.append($('<input>', { type: 'hidden', name: 'productos[' + indice + '][cantidad]', value: partida.cantidad }));
       $celdaSku.append($('<input>', { type: 'hidden', name: 'productos[' + indice + '][otro]', value: partida.esOtro ? '1' : '0' }));
+      $celdaSku.append($('<input>', { type: 'hidden', name: 'productos[' + indice + '][solicitado]', value: partida.solicitado ? '1' : '0' }));
 
       $celdaAcciones.append($botonEliminar);
       $fila.append($celdaSku, $celdaCantidad, $celdaAcciones, $celdaDescripcion);
@@ -524,7 +560,8 @@ $(document).ready(function() {
     return {
       id: valorSeleccionado,
       sku: (seleccionado.sku || '').toString().trim(),
-      descripcion: (seleccionado.descripcion || seleccionado.text || '').toString().trim()
+      descripcion: (seleccionado.descripcion || seleccionado.text || '').toString().trim(),
+      solicitado: !!seleccionado.solicitado
     };
   }
 
@@ -602,7 +639,19 @@ $(document).ready(function() {
       var datosProducto = obtenerDatosProductoSeleccionado();
       var cantidad = parseInt($inputCantidadPendiente.val(), 10);
 
-      if (!datosProducto.id || isNaN(cantidad) || cantidad <= 0) {
+      if (isNaN(cantidad) || cantidad <= 0) {
+        return;
+      }
+
+      if (datosProducto.solicitado) {
+        var skuSolicitado = datosProducto.sku || (($selectProductoPendiente.val() || '').toString().replace(/^solicitar:/, ''));
+        if (!skuSolicitado) { skuSolicitado = window.prompt('Captura el SKU que deseas solicitar:') || ''; }
+        skuSolicitado = skuSolicitado.trim();
+        if (!skuSolicitado) { return; }
+        datosProducto.id = null;
+        datosProducto.sku = skuSolicitado;
+        datosProducto.descripcion = 'SOLICITADO';
+      } else if (!datosProducto.id) {
         return;
       }
 
@@ -611,7 +660,8 @@ $(document).ready(function() {
         sku: datosProducto.sku,
         descripcion: datosProducto.descripcion,
         cantidad: cantidad,
-        esOtro: false
+        esOtro: false,
+        solicitado: !!datosProducto.solicitado
       });
     }
 
@@ -1587,7 +1637,8 @@ $(document).ready(function() {
         sku: productoEncontrado && productoEncontrado.sku ? productoEncontrado.sku : sku,
         descripcion: productoEncontrado && productoEncontrado.descripcion ? productoEncontrado.descripcion : descripcion,
         cantidad: cantidad,
-        esOtro: esOtro
+        esOtro: esOtro,
+        solicitado: descripcion === 'SOLICITADO'
       };
     });
 
@@ -1683,6 +1734,207 @@ $(document).ready(function() {
       mostrarErrorDetalle('No se pudieron cargar las partidas.');
     });
   }
+
+
+
+
+  function obtenerInstanciaModalSolicitudes() {
+    if (!$modalSolicitudes.length || !window.bootstrap || typeof window.bootstrap.Modal !== 'function') {
+      return null;
+    }
+
+    if (instanciaModalSolicitudes) {
+      return instanciaModalSolicitudes;
+    }
+
+    if (typeof window.bootstrap.Modal.getInstance === 'function') {
+      instanciaModalSolicitudes = window.bootstrap.Modal.getInstance($modalSolicitudes[0]);
+    }
+
+    if (!instanciaModalSolicitudes) {
+      instanciaModalSolicitudes = new window.bootstrap.Modal($modalSolicitudes[0]);
+    }
+
+    return instanciaModalSolicitudes;
+  }
+
+  function mostrarModalSolicitudes() {
+    var modalSolicitudes = obtenerInstanciaModalSolicitudes();
+
+    if (modalSolicitudes && typeof modalSolicitudes.show === 'function') {
+      modalSolicitudes.show();
+      return;
+    }
+
+    if (typeof $modalSolicitudes.modal === 'function') {
+      $modalSolicitudes.modal('show');
+    }
+  }
+
+  function ocultarModalSolicitudes() {
+    var modalSolicitudes = obtenerInstanciaModalSolicitudes();
+
+    if (modalSolicitudes && typeof modalSolicitudes.hide === 'function') {
+      modalSolicitudes.hide();
+      return;
+    }
+
+    if (typeof $modalSolicitudes.modal === 'function') {
+      $modalSolicitudes.modal('hide');
+    }
+  }
+
+
+  function obtenerInstanciaModalBootstrap($modalObjetivo, instanciaActual) {
+    if (!$modalObjetivo.length || !window.bootstrap || typeof window.bootstrap.Modal !== 'function') {
+      return null;
+    }
+
+    if (instanciaActual) {
+      return instanciaActual;
+    }
+
+    var instancia = null;
+    if (typeof window.bootstrap.Modal.getInstance === 'function') {
+      instancia = window.bootstrap.Modal.getInstance($modalObjetivo[0]);
+    }
+
+    if (!instancia) {
+      instancia = new window.bootstrap.Modal($modalObjetivo[0]);
+    }
+
+    return instancia;
+  }
+
+  function obtenerInstanciaModalAgregarClientes() {
+    instanciaModalAgregarClientes = obtenerInstanciaModalBootstrap($modalAgregarClientes, instanciaModalAgregarClientes);
+    return instanciaModalAgregarClientes;
+  }
+
+  function obtenerInstanciaModalAgregarProductos() {
+    instanciaModalAgregarProductos = obtenerInstanciaModalBootstrap($modalAgregarProductos, instanciaModalAgregarProductos);
+    return instanciaModalAgregarProductos;
+  }
+
+  function mostrarModalBootstrap($modalObjetivo, obtenerInstancia) {
+    var instancia = obtenerInstancia();
+
+    if (instancia && typeof instancia.show === 'function') {
+      instancia.show();
+      return;
+    }
+
+    if (typeof $modalObjetivo.modal === 'function') {
+      $modalObjetivo.modal('show');
+    }
+  }
+
+  function ocultarModalBootstrap($modalObjetivo, obtenerInstancia) {
+    var instancia = obtenerInstancia();
+
+    if (instancia && typeof instancia.hide === 'function') {
+      instancia.hide();
+      return;
+    }
+
+    if (typeof $modalObjetivo.modal === 'function') {
+      $modalObjetivo.modal('hide');
+    }
+  }
+
+  function mostrarModalAgregarClientes() {
+    mostrarModalBootstrap($modalAgregarClientes, obtenerInstanciaModalAgregarClientes);
+  }
+
+  function mostrarModalAgregarProductos() {
+    mostrarModalBootstrap($modalAgregarProductos, obtenerInstanciaModalAgregarProductos);
+  }
+
+  function ocultarModalAgregarClientes() {
+    ocultarModalBootstrap($modalAgregarClientes, obtenerInstanciaModalAgregarClientes);
+  }
+
+  function ocultarModalAgregarProductos() {
+    ocultarModalBootstrap($modalAgregarProductos, obtenerInstanciaModalAgregarProductos);
+  }
+
+  function abrirModalDespuesDeSolicitudes(mostrarModalAtencion) {
+    var abrir = function() {
+      window.setTimeout(function() {
+        mostrarModalAtencion();
+      }, 50);
+    };
+
+    if ($modalSolicitudes.length && $modalSolicitudes.hasClass('show')) {
+      $modalSolicitudes.one('hidden.bs.modal', abrir);
+      ocultarModalSolicitudes();
+      return;
+    }
+
+    abrir();
+  }
+
+  function cargarSolicitudesMP(tipo) {
+    tipoSolicitudActual = tipo;
+    var $body = $('#SolicitudesMPBody');
+    $('#ModalSolicitudesMPLabel').text(tipo === 'clientes' ? 'Solicitudes de clientes' : 'Solicitudes de productos');
+    $body.html('<tr><td colspan="3" class="text-center text-muted">Cargando solicitudes…</td></tr>');
+    $.getJSON('App/Server/ServerSolicitudesMaterialPendiente.php', { tipo: tipo }).done(function(respuesta) {
+      if (!respuesta || !respuesta.success || !respuesta.records || !respuesta.records.length) {
+        $body.html('<tr><td colspan="3" class="text-center text-muted">No hay solicitudes pendientes.</td></tr>');
+        return;
+      }
+      $body.html(respuesta.records.map(function(r) {
+        return '<tr><td>' + escaparHtml(r.valor || '') + '</td><td>' + escaparHtml(r.fecha || '-') + '</td><td class="text-end"><button type="button" class="btn btn-sm btn-primary atender-solicitud-mp" data-valor="' + escaparHtml(r.valor || '') + '">Agregar</button></td></tr>';
+      }).join(''));
+    }).fail(function() {
+      $body.html('<tr><td colspan="3" class="text-center text-danger">No se pudieron cargar las solicitudes.</td></tr>');
+    });
+    mostrarModalSolicitudes();
+  }
+
+  if ($modalSolicitudes.length) {
+    $modalSolicitudes.on('shown.bs.modal', function() {
+      $modalSolicitudes.css('z-index', 1060);
+      $('.modal-backdrop').last().css('z-index', 1055);
+    });
+  }
+
+  $modalAgregarClientes.add($modalAgregarProductos).on('shown.bs.modal', function() {
+    $(this).css('z-index', 1070);
+    $('.modal-backdrop').last().css('z-index', 1065);
+  });
+
+  $('#BtnSolicitudesClientesMP').on('click', function() { cargarSolicitudesMP('clientes'); });
+  $('#BtnSolicitudesProductosMP').on('click', function() { cargarSolicitudesMP('productos'); });
+  $('#SolicitudesMPBody').on('click', '.atender-solicitud-mp', function() {
+    valorSolicitudActual = ($(this).data('valor') || '').toString();
+    if (tipoSolicitudActual === 'clientes') {
+      $('#ValidacionAgregarClientes')[0] && $('#ValidacionAgregarClientes')[0].reset();
+      $('#CLIENTESIAN').val(valorSolicitudActual);
+      abrirModalDespuesDeSolicitudes(mostrarModalAgregarClientes);
+      return;
+    }
+    $('#ValidacionAgregarProductos')[0] && $('#ValidacionAgregarProductos')[0].reset();
+    $('#Sku').val(valorSolicitudActual);
+    abrirModalDespuesDeSolicitudes(mostrarModalAgregarProductos);
+  });
+
+  $('#ValidacionAgregarClientes').on('submit', function(evento) {
+    evento.preventDefault();
+    var $form = $(this);
+    $.ajax({ type: 'POST', url: 'App/Server/ServerInsertarClientes.php', data: $form.serialize(), dataType: 'json' })
+      .done(function() { ocultarModalAgregarClientes(); cargarSolicitudesMP('clientes'); })
+      .fail(function(xhr) { mostrarMensajeError((xhr.responseJSON && xhr.responseJSON.error) || 'No se pudo agregar el cliente.'); });
+  });
+
+  $('#ValidacionAgregarProductos').on('submit', function(evento) {
+    evento.preventDefault();
+    var $form = $(this);
+    $.ajax({ type: 'POST', url: 'App/Server/ServerInsertarProductos.php', data: $form.serialize(), dataType: 'json' })
+      .done(function() { ocultarModalAgregarProductos(); cargarSolicitudesMP('productos'); })
+      .fail(function(xhr) { mostrarMensajeError((xhr.responseJSON && xhr.responseJSON.error) || 'No se pudo agregar el producto.'); });
+  });
 
   if ($buscadorMaterialPendiente.length) {
     $buscadorMaterialPendiente.on('input', function() {
@@ -2179,6 +2431,21 @@ $(document).ready(function() {
   });
 
   $selectRazonSocial.on('change select2:select', function() {
+    var datos = $selectRazonSocial.hasClass('select2-hidden-accessible') ? $selectRazonSocial.select2('data') : [];
+    var seleccionado = datos && datos.length ? datos[0] : null;
+    if (seleccionado && seleccionado.solicitado) {
+      var numero = (seleccionado.numeroCliente || ($selectRazonSocial.val() || '').toString().replace(/^solicitar:/, '')).trim();
+      if (!numero) { numero = window.prompt('Captura el número de cliente que deseas solicitar:') || ''; }
+      numero = numero.trim();
+      if (numero) {
+        $checkboxOtraRazonSocial.prop('checked', true);
+        actualizarCamposOtraRazonSocial();
+        $inputNumeroClientePendienteOtro.val(numero);
+        $inputRazonSocialPendienteOtra.val('SOLICITADO');
+        $inputNombreCliente.val('SOLICITADO');
+      }
+      return;
+    }
     enfocarCampo($selectVendedores);
   });
 

--- a/MaterialPendiente.php
+++ b/MaterialPendiente.php
@@ -347,6 +347,12 @@ if (isset($_SESSION['TIPOUSUARIO']) && (int) $_SESSION['TIPOUSUARIO'] === 3) {
                                     <i class="material-icons-two-tone">file_download</i>
                                     Exportar Excel
                                 </a>
+                                <button type="button" class="btn btn-sm btn-outline-primary waves-effect width-md waves-light ms-2" id="BtnSolicitudesClientesMP">
+                                    Solicitudes de clientes
+                                </button>
+                                <button type="button" class="btn btn-sm btn-outline-primary waves-effect width-md waves-light ms-2" id="BtnSolicitudesProductosMP">
+                                    Solicitudes de productos
+                                </button>
                                 <?php if ($esSoporteITMaterialPendiente) : ?>
                                     <button type="button" class="btn btn-sm btn-outline-warning waves-effect width-md waves-light ms-2" id="BtnVerEliminadosMaterialPendiente">
                                         <i class="material-icons-two-tone">restore_from_trash</i>
@@ -562,6 +568,16 @@ if (isset($_SESSION['TIPOUSUARIO']) && (int) $_SESSION['TIPOUSUARIO'] === 3) {
     </div>
 
     <?php include("App/Modales/ModalesMaterialPendiente.php") ?>
+    <?php include("App/Modales/ModalesClientes.php") ?>
+    <?php include("App/Modales/ModalesProductos.php") ?>
+
+    <div class="modal fade" id="ModalSolicitudesMP" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable"><div class="modal-content">
+            <div class="modal-header"><h5 class="modal-title" id="ModalSolicitudesMPLabel">Solicitudes</h5><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button></div>
+            <div class="modal-body"><div class="table-responsive"><table class="table table-sm align-middle"><thead><tr><th>Valor solicitado</th><th>Fecha</th><th class="text-end">Acciones</th></tr></thead><tbody id="SolicitudesMPBody"><tr><td colspan="3" class="text-center text-muted">Sin solicitudes.</td></tr></tbody></table></div></div>
+            <div class="modal-footer"><button type="button" class="btn btn-light" data-bs-dismiss="modal">Cerrar</button></div>
+        </div></div>
+    </div>
 
     <?php if ($esSoporteITMaterialPendiente) : ?>
         <div class="modal fade" id="ModalMaterialPendienteEliminado" tabindex="-1" aria-labelledby="ModalMaterialPendienteEliminadoLabel" aria-hidden="true">

--- a/includes/MandarEmail.php
+++ b/includes/MandarEmail.php
@@ -108,6 +108,102 @@ function RecuperaTuPassword($email, $Hash)
     return false;
 }
 
+function EnviarNotificacionSolicitudMaterialPendiente(array $numerosCliente, array $skusProductos, string $documento = '')
+{
+    $numerosCliente = array_values(array_unique(array_filter(array_map('trim', $numerosCliente))));
+    $skusProductos = array_values(array_unique(array_filter(array_map('trim', $skusProductos))));
+
+    if (empty($numerosCliente) && empty($skusProductos)) {
+        return true;
+    }
+
+    $smtpUser = obtenerVariableEntorno('SMTP_USER', 'apps@edison.com.mx');
+    $smtpPass = obtenerVariableEntorno('SMTP_PASS', '');
+    $smtpDebug = obtenerVariableEntorno('APP_DEBUG', '0');
+
+    if ($smtpPass === '') {
+        error_log('PHPMailer CONFIG ERROR: SMTP_PASS no está configurado para notificación de solicitudes de material pendiente.');
+        return false;
+    }
+
+    $documentoHtml = htmlspecialchars($documento, ENT_QUOTES, 'UTF-8');
+    $clientesHtml = '';
+    foreach ($numerosCliente as $numeroCliente) {
+        $clientesHtml .= '<li>' . htmlspecialchars($numeroCliente, ENT_QUOTES, 'UTF-8') . '</li>';
+    }
+
+    $productosHtml = '';
+    foreach ($skusProductos as $skuProducto) {
+        $productosHtml .= '<li>' . htmlspecialchars($skuProducto, ENT_QUOTES, 'UTF-8') . '</li>';
+    }
+
+    $mailBody = '<html><body>'
+        . '<p>Se generó una nueva solicitud desde la sección de Material Pendiente.</p>'
+        . ($documentoHtml !== '' ? '<p><strong>Documento:</strong> ' . $documentoHtml . '</p>' : '')
+        . (!empty($numerosCliente) ? '<p><strong>Clientes solicitados:</strong></p><ul>' . $clientesHtml . '</ul>' : '')
+        . (!empty($skusProductos) ? '<p><strong>Productos solicitados (SKU):</strong></p><ul>' . $productosHtml . '</ul>' : '')
+        . '<p style="font-size:12px;color:#666;">Este es un correo automático, no respondas a este mensaje.</p>'
+        . '</body></html>';
+
+    $altBody = "Se generó una nueva solicitud desde Material Pendiente.";
+    if ($documento !== '') {
+        $altBody .= "\nDocumento: " . $documento;
+    }
+    if (!empty($numerosCliente)) {
+        $altBody .= "\nClientes solicitados: " . implode(', ', $numerosCliente);
+    }
+    if (!empty($skusProductos)) {
+        $altBody .= "\nProductos solicitados (SKU): " . implode(', ', $skusProductos);
+    }
+
+    $estrategiasSmtp = array(
+        array('seguridad' => PHPMailer::ENCRYPTION_STARTTLS, 'puerto' => 587, 'label' => 'STARTTLS-587'),
+        array('seguridad' => PHPMailer::ENCRYPTION_SMTPS, 'puerto' => 465, 'label' => 'SMTPS-465'),
+    );
+
+    foreach ($estrategiasSmtp as $estrategia) {
+        $mail = new PHPMailer(true);
+
+        try {
+            $mail->isSMTP();
+            $mail->Host       = 'mail.edison.com.mx';
+            $mail->Port       = $estrategia['puerto'];
+            $mail->SMTPAuth   = true;
+            $mail->SMTPSecure = $estrategia['seguridad'];
+            $mail->Username   = $smtpUser;
+            $mail->Password   = $smtpPass;
+            $mail->SMTPDebug = $smtpDebug === '1' ? 2 : 0;
+            $mail->Debugoutput = function ($str, $level) {
+                error_log("PHPMailer [$level]: $str");
+            };
+            $mail->SMTPOptions = array(
+                'ssl' => array(
+                    'verify_peer' => false,
+                    'verify_peer_name' => false,
+                    'allow_self_signed' => true,
+                ),
+            );
+            $mail->Timeout = 10;
+
+            $mail->setFrom('apps@edison.com.mx', 'Edison Apps');
+            $mail->addAddress('sistemas@edison.com.mx');
+            $mail->Subject = 'Nueva solicitud en Material Pendiente';
+            $mail->CharSet = 'UTF-8';
+            $mail->isHTML(true);
+            $mail->Body = $mailBody;
+            $mail->AltBody = $altBody;
+
+            $mail->send();
+            return true;
+        } catch (Exception $e) {
+            error_log('PHPMailer ERROR solicitud material pendiente [' . $estrategia['label'] . ']: ' . $mail->ErrorInfo);
+            error_log('PHPMailer EXCEPTION solicitud material pendiente [' . $estrategia['label'] . ']: ' . $e->getMessage());
+        }
+    }
+
+    return false;
+}
+
 // RecuperaTuPassword('sistemas@edison.com.mx', '123123123');
 // RecuperaTuPassword('aguevara@studioa.com.mx', '123123123');
 


### PR DESCRIPTION
### Motivation
- Provide a way for users to request missing clients or product SKUs from the Material Pendiente workflow and track/attend those requests. 
- Persist and index requests in the database and notify support when new requests are created so they can be addressed.

### Description
- UI: added buttons and a modal to view pending solicitudes and modals to add requested clients/products in `MaterialPendiente.php`, updated `App/Modales/ModalesMaterialPendiente.php` to allow "Solicitar" behavior and removed disabling of some inputs so requests can be created without catalog entries. 
- JS: extended `App/js/AppMaterialPendiente.js` to inject a "Solicitar" option into product/client selects, handle create/attend flows, store a `solicitado` flag on partidas, provide modals and interaction handlers to open the request list and to open add-client/product forms from a request, and include form submission handling to mark requests as attended. 
- Server/DB: introduced `Solicitud_Clientes` and `Solicitud_Productos` tables and ensured they are created by `ServerInsertarMaterialPendiente.php`, `ServerActualizarMaterialPendiente.php`, `ServerInsertarClientes.php`, and `ServerInsertarProductos.php`; implemented a new endpoint `App/Server/ServerSolicitudesMaterialPendiente.php` to list pending requests. 
- Request lifecycle: when a pending partida is flagged as requested, server-side insert/update handlers record the SKU/client into the new tables; when a client/product is later added through the existing insert endpoints, matching requests are marked as attended and relevant pending records are updated (`facturamp`/`materialpendiente`). 
- Notifications: added `EnviarNotificacionSolicitudMaterialPendiente` to `includes/MandarEmail.php` that builds and sends an email to `sistemas@edison.com.mx` (via configured SMTP credentials) when new solicitudes are created. 

### Testing
- Performed PHP syntax checks on modified PHP files using `php -l`, which completed without syntax errors. 
- Exercised the new requests listing endpoint (`App/Server/ServerSolicitudesMaterialPendiente.php`) and basic add/attend flows via automated HTTP requests during development and verified JSON responses and DB inserts/updates succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a357f5fa8588327b7bf7fd8fc6326bb)