### PR TITLE
Evitar SKUs duplicados en productos y en solicitudes; mejorar UI y manejo de errores

### DIFF
--- a/App/Server/ServerActualizarMaterialPendiente.php
+++ b/App/Server/ServerActualizarMaterialPendiente.php
@@ -15,6 +15,34 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     responderError('Método no permitido.', 405);
 }
 
+function obtenerSkuProductoExistente(mysqli $conn, array $skus): string
+{
+    if (empty($skus)) {
+        return '';
+    }
+
+    $stmt = mysqli_prepare($conn, 'SELECT Sku FROM productos WHERE Sku = ? LIMIT 1');
+    if (!$stmt) {
+        return '';
+    }
+
+    foreach (array_keys($skus) as $skuSolicitado) {
+        mysqli_stmt_bind_param($stmt, 's', $skuSolicitado);
+        mysqli_stmt_execute($stmt);
+        mysqli_stmt_bind_result($stmt, $skuExistente);
+
+        if (mysqli_stmt_fetch($stmt)) {
+            mysqli_stmt_close($stmt);
+            return (string) $skuExistente;
+        }
+
+        mysqli_stmt_free_result($stmt);
+    }
+
+    mysqli_stmt_close($stmt);
+    return '';
+}
+
 if (!$conn) {
     responderError('No se pudo conectar a la base de datos.');
 }
@@ -303,6 +331,11 @@ foreach ($productos as $producto) {
 
 if (empty($productosValidos)) {
     responderError('Agrega al menos una partida pendiente válida.', 400);
+}
+
+$skuProductoExistente = obtenerSkuProductoExistente($conn, $skusSolicitados);
+if ($skuProductoExistente !== '') {
+    responderError('No se puede generar una solicitud para el SKU ' . $skuProductoExistente . ' porque ya existe en el registro de productos.', 409);
 }
 
 mysqli_begin_transaction($conn);

--- a/App/Server/ServerInsertarMaterialPendiente.php
+++ b/App/Server/ServerInsertarMaterialPendiente.php
@@ -15,6 +15,34 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     responderError('Método no permitido.', 405);
 }
 
+function obtenerSkuProductoExistente(mysqli $conn, array $skus): string
+{
+    if (empty($skus)) {
+        return '';
+    }
+
+    $stmt = mysqli_prepare($conn, 'SELECT Sku FROM productos WHERE Sku = ? LIMIT 1');
+    if (!$stmt) {
+        return '';
+    }
+
+    foreach (array_keys($skus) as $skuSolicitado) {
+        mysqli_stmt_bind_param($stmt, 's', $skuSolicitado);
+        mysqli_stmt_execute($stmt);
+        mysqli_stmt_bind_result($stmt, $skuExistente);
+
+        if (mysqli_stmt_fetch($stmt)) {
+            mysqli_stmt_close($stmt);
+            return (string) $skuExistente;
+        }
+
+        mysqli_stmt_free_result($stmt);
+    }
+
+    mysqli_stmt_close($stmt);
+    return '';
+}
+
 if (!$conn) {
     responderError('No se pudo conectar a la base de datos.');
 }
@@ -291,6 +319,11 @@ foreach ($productos as $producto) {
 
 if (empty($productosValidos)) {
     responderError('Agrega al menos una partida pendiente válida.', 400);
+}
+
+$skuProductoExistente = obtenerSkuProductoExistente($conn, $skusSolicitados);
+if ($skuProductoExistente !== '') {
+    responderError('No se puede generar una solicitud para el SKU ' . $skuProductoExistente . ' porque ya existe en el registro de productos.', 409);
 }
 
 $stmtDocumento = mysqli_prepare(

--- a/App/Server/ServerInsertarProductos.php
+++ b/App/Server/ServerInsertarProductos.php
@@ -17,7 +17,24 @@ if ($sku === '') {
     exit;
 }
 
-$skuSql = "'" . mysqli_real_escape_string($conn, $sku) . "'";
+$skuEscapado = mysqli_real_escape_string($conn, $sku);
+$consultaSkuDuplicado = mysqli_query($conn, "SELECT PRODUCTOSID FROM productos WHERE Sku = '$skuEscapado' LIMIT 1");
+
+if ($consultaSkuDuplicado && mysqli_num_rows($consultaSkuDuplicado) > 0) {
+    http_response_code(409);
+    echo json_encode([
+        'error' => 'Ya existe un producto registrado con el SKU capturado.'
+    ]);
+    mysqli_free_result($consultaSkuDuplicado);
+    mysqli_close($conn);
+    exit;
+}
+
+if ($consultaSkuDuplicado) {
+    mysqli_free_result($consultaSkuDuplicado);
+}
+
+$skuSql = "'" . $skuEscapado . "'";
 $descripcionSql = ($descripcion !== '') ? "'" . mysqli_real_escape_string($conn, $descripcion) . "'" : "NULL";
 $marcaSql = ($marcaProductos !== '') ? "'" . mysqli_real_escape_string($conn, $marcaProductos) . "'" : "NULL";
 
@@ -31,7 +48,7 @@ $lastId = mysqli_insert_id($conn);
 
 @mysqli_query($conn, "CREATE TABLE IF NOT EXISTS Solicitud_Productos (SolicitudProductoID INT NOT NULL AUTO_INCREMENT, SKU VARCHAR(100) NOT NULL, Atendida TINYINT(1) NOT NULL DEFAULT 0, FechaSolicitud TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, FechaAtencion TIMESTAMP NULL DEFAULT NULL, PRIMARY KEY (SolicitudProductoID), INDEX idx_solicitud_producto_estado (Atendida), INDEX idx_solicitud_producto_sku (SKU)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
 
-$skuEscapadoActualizar = mysqli_real_escape_string($conn, $sku);
+$skuEscapadoActualizar = $skuEscapado;
 $descripcionEscapadaActualizar = mysqli_real_escape_string($conn, $descripcion !== '' ? $descripcion : 'SOLICITADO');
 @mysqli_query($conn, "UPDATE Solicitud_Productos SET Atendida = 1, FechaAtencion = NOW() WHERE SKU = '$skuEscapadoActualizar' AND Atendida = 0");
 @mysqli_query($conn, "UPDATE materialpendiente SET DescripcionMP = '$descripcionEscapadaActualizar' WHERE SkuMP = '$skuEscapadoActualizar' AND DescripcionMP = 'SOLICITADO'");

--- a/App/Server/ServerUpdateProductos.php
+++ b/App/Server/ServerUpdateProductos.php
@@ -18,7 +18,24 @@ if ($productosId <= 0 || $sku === '') {
     exit;
 }
 
-$skuSql = "'" . mysqli_real_escape_string($conn, $sku) . "'";
+$skuEscapado = mysqli_real_escape_string($conn, $sku);
+$consultaSkuDuplicado = mysqli_query($conn, "SELECT PRODUCTOSID FROM productos WHERE Sku = '$skuEscapado' AND PRODUCTOSID <> $productosId LIMIT 1");
+
+if ($consultaSkuDuplicado && mysqli_num_rows($consultaSkuDuplicado) > 0) {
+    http_response_code(409);
+    echo json_encode([
+        'error' => 'Ya existe otro producto registrado con el SKU capturado.'
+    ]);
+    mysqli_free_result($consultaSkuDuplicado);
+    mysqli_close($conn);
+    exit;
+}
+
+if ($consultaSkuDuplicado) {
+    mysqli_free_result($consultaSkuDuplicado);
+}
+
+$skuSql = "'" . $skuEscapado . "'";
 $descripcionSql = ($descripcion !== '') ? "'" . mysqli_real_escape_string($conn, $descripcion) . "'" : "NULL";
 $marcaSql = ($marcaProductos !== '') ? "'" . mysqli_real_escape_string($conn, $marcaProductos) . "'" : "NULL";
 

--- a/App/js/AppMaterialPendiente.js
+++ b/App/js/AppMaterialPendiente.js
@@ -216,6 +216,19 @@ $(document).ready(function() {
     return sku || descripcion;
   }
 
+
+  function existeSkuExactoEnResultados(resultados, skuBuscado) {
+    skuBuscado = (skuBuscado || '').toString().trim().toLowerCase();
+
+    if (!skuBuscado) {
+      return false;
+    }
+
+    return resultados.some(function(item) {
+      return ((item && item.sku ? item.sku : '').toString().trim().toLowerCase()) === skuBuscado;
+    });
+  }
+
   function inicializarSelect2($elemento) {
     if (!$elemento.length || typeof $elemento.select2 !== 'function') {
       return;
@@ -263,13 +276,16 @@ $(document).ready(function() {
             });
           }
 
-          resultados.unshift({
-            id: 'solicitar:' + (params.term || ''),
-            text: 'Solicitar',
-            sku: (params.term || '').toString().trim(),
-            descripcion: 'SOLICITADO',
-            solicitado: true
-          });
+          var skuSolicitado = (params.term || '').toString().trim();
+          if (!existeSkuExactoEnResultados(resultados, skuSolicitado)) {
+            resultados.unshift({
+              id: 'solicitar:' + (params.term || ''),
+              text: 'Solicitar',
+              sku: skuSolicitado,
+              descripcion: 'SOLICITADO',
+              solicitado: true
+            });
+          }
 
           return {
             results: resultados,
@@ -2532,8 +2548,11 @@ $(document).ready(function() {
 
         var mensaje = respuesta && respuesta.message ? respuesta.message : '';
         mostrarMensajeError(mensaje);
-      }).fail(function() {
-        mostrarMensajeError('No se pudo guardar el material pendiente. Inténtalo nuevamente.');
+      }).fail(function(xhr) {
+        var mensaje = xhr.responseJSON && xhr.responseJSON.message
+          ? xhr.responseJSON.message
+          : 'No se pudo guardar el material pendiente. Inténtalo nuevamente.';
+        mostrarMensajeError(mensaje);
       });
     });
   }

--- a/App/js/AppProductos.js
+++ b/App/js/AppProductos.js
@@ -1,4 +1,14 @@
 $(document).ready(function() {
+  function mostrarErrorProducto(xhr, mensajeDefault) {
+    var mensaje = mensajeDefault || "No se pudo guardar el producto.";
+
+    if (xhr.responseJSON && xhr.responseJSON.error) {
+      mensaje = xhr.responseJSON.error;
+    }
+
+    window.alert(mensaje);
+  }
+
   var dataTableProductosDT = $("#ProductosDT").DataTable({
     dom: "Bifrtip",
     buttons: ["excelHtml5", "pdfHtml5", "pageLength"],
@@ -45,11 +55,13 @@ $(document).ready(function() {
       dataType: "json",
       success: function() {
         dataTableProductosDT.columns.adjust().draw();
+        $("#ModalAgregarProductos").modal("toggle");
+        form[0].reset();
+      },
+      error: function(xhr) {
+        mostrarErrorProducto(xhr, "No se pudo agregar el producto.");
       }
     });
-
-    $("#ModalAgregarProductos").modal("toggle");
-    form[0].reset();
   });
 
   $("#ValidacionEditarProductos").on("submit", function(e) {
@@ -69,10 +81,12 @@ $(document).ready(function() {
       dataType: "json",
       success: function() {
         dataTableProductosDT.columns.adjust().draw();
+        $("#ModalEditarProductos").modal("toggle");
+      },
+      error: function(xhr) {
+        mostrarErrorProducto(xhr, "No se pudo actualizar el producto.");
       }
     });
-
-    $("#ModalEditarProductos").modal("toggle");
   });
 
   $("body").on("click", "#BorrarProducto", function() {


### PR DESCRIPTION
### Motivation
- Evitar generar solicitudes de material para SKUs que ya existen en el catálogo y prevenir la creación/actualización de productos con SKUs duplicados, además de mejorar la experiencia de usuario mostrando mensajes de error del servidor y evitando opciones redundantes en el selector.

### Description
- Se agregó la función `obtenerSkuProductoExistente` y su uso en `ServerInsertarMaterialPendiente.php` y `ServerActualizarMaterialPendiente.php` para bloquear la creación/actualización de solicitudes cuando algún SKU solicitado ya exista, devolviendo `409` con mensaje explicativo.
- Se agregó verificación de duplicados en `ServerInsertarProductos.php` y `ServerUpdateProductos.php` que consulta la tabla `productos` antes de insertar/actualizar y responde `409` si existe conflicto, además de mejorar el escape de entradas y limpieza de resultados de consulta.
- En `App/js/AppMaterialPendiente.js` se evita insertar la opción "Solicitar" en Select2 cuando los resultados ya contienen exactamente el SKU buscado y se muestra el mensaje devuelto por el servidor en el `fail` de la petición AJAX.
- En `App/js/AppProductos.js` se centralizó la presentación de errores con `mostrarErrorProducto`, se mostró el mensaje de error proveniente del servidor en los callbacks `error`, y se cambió el cierre/reset de modales para que ocurra solo después de un éxito.

### Testing
- No se añadieron ni ejecutaron pruebas automatizadas en este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36b386489883279779b7b19242f9e6)