### PR TITLE
Restringir acciones de solicitudes a Administrador y Soporte IT

### DIFF
--- a/App/Server/ServerSolicitudesMaterialPendiente.php
+++ b/App/Server/ServerSolicitudesMaterialPendiente.php
@@ -1,8 +1,40 @@
 <?php
 include("../../Connections/ConDB.php");
+
+if (!isset($_SESSION)) {
+    session_start();
+}
+
 header('Content-Type: application/json');
 
 function responder($data, int $code = 200): void { http_response_code($code); echo json_encode($data); exit; }
+function puedeGestionarAccionesSolicitudes(mysqli $conn): bool {
+    $tipoUsuarioId = (int) ($_SESSION['TIPOUSUARIO'] ?? 0);
+
+    if (in_array($tipoUsuarioId, [1, 9], true)) {
+        return true;
+    }
+
+    $tipoUsuario = strtolower(trim((string) ($_SESSION['TipoDeUsuario'] ?? '')));
+
+    if ($tipoUsuario === '' && $tipoUsuarioId > 0) {
+        $stmt = mysqli_prepare($conn, 'SELECT TipoDeUsuario FROM tipodeusuarios WHERE TIPODEUSUARIOID = ? LIMIT 1');
+
+        if ($stmt) {
+            mysqli_stmt_bind_param($stmt, 'i', $tipoUsuarioId);
+            mysqli_stmt_execute($stmt);
+            mysqli_stmt_bind_result($stmt, $tipoUsuarioRecuperado);
+
+            if (mysqli_stmt_fetch($stmt)) {
+                $tipoUsuario = strtolower(trim((string) $tipoUsuarioRecuperado));
+            }
+
+            mysqli_stmt_close($stmt);
+        }
+    }
+
+    return in_array($tipoUsuario, ['administrador', 'soporte it'], true);
+}
 function asegurar(mysqli $conn): void {
     @mysqli_query($conn, "CREATE TABLE IF NOT EXISTS Solicitud_Clientes (
         SolicitudClienteID INT NOT NULL AUTO_INCREMENT,
@@ -23,10 +55,15 @@ function asegurar(mysqli $conn): void {
 }
 if (!$conn) responder(['success'=>false,'message'=>'No se pudo conectar a la base de datos.'],500);
 asegurar($conn);
+$puedeGestionarAcciones = puedeGestionarAccionesSolicitudes($conn);
 $tipo = strtolower(trim($_GET['tipo'] ?? $_POST['tipo'] ?? ''));
 $accion = strtolower(trim($_POST['accion'] ?? $_GET['accion'] ?? 'listar'));
 
 if ($accion === 'eliminar') {
+    if (!$puedeGestionarAcciones) {
+        responder(['success' => false, 'message' => 'No tienes permisos para gestionar las solicitudes.'], 403);
+    }
+
     $id = isset($_POST['id']) ? (int) $_POST['id'] : (int) ($_GET['id'] ?? 0);
 
     if ($id <= 0) {
@@ -62,4 +99,4 @@ if ($tipo === 'clientes') {
     $rs = mysqli_query($conn, "SELECT SolicitudProductoID id, SKU valor, FechaSolicitud fecha FROM Solicitud_Productos WHERE Atendida = 0 ORDER BY SolicitudProductoID DESC");
 } else responder(['success'=>false,'message'=>'Tipo de solicitud inválido.'],400);
 $records=[]; if ($rs instanceof mysqli_result) { while($r=mysqli_fetch_assoc($rs)) $records[]=$r; }
-responder(['success'=>true,'records'=>$records]);
+responder(['success'=>true,'records'=>$records,'puedeGestionarAcciones'=>$puedeGestionarAcciones]);

--- a/App/js/AppMaterialPendiente.js
+++ b/App/js/AppMaterialPendiente.js
@@ -1918,11 +1918,14 @@ $(document).ready(function() {
         $body.html('<tr><td colspan="3" class="text-center text-muted">No hay solicitudes pendientes.</td></tr>');
         return;
       }
+      var puedeGestionarAcciones = respuesta.puedeGestionarAcciones === true;
       $body.html(respuesta.records.map(function(r) {
-        return '<tr><td>' + escaparHtml(r.valor || '') + '</td><td>' + escaparHtml(r.fecha || '-') + '</td><td class="text-end">' +
-          '<button type="button" class="btn btn-sm btn-primary atender-solicitud-mp me-2" data-valor="' + escaparHtml(r.valor || '') + '">Agregar</button>' +
-          '<button type="button" class="btn btn-sm btn-outline-danger eliminar-solicitud-mp" data-id="' + escaparHtml(r.id || '') + '" data-valor="' + escaparHtml(r.valor || '') + '">Eliminar</button>' +
-        '</td></tr>';
+        var acciones = puedeGestionarAcciones
+          ? '<button type="button" class="btn btn-sm btn-primary atender-solicitud-mp me-2" data-valor="' + escaparHtml(r.valor || '') + '">Agregar</button>' +
+            '<button type="button" class="btn btn-sm btn-outline-danger eliminar-solicitud-mp" data-id="' + escaparHtml(r.id || '') + '" data-valor="' + escaparHtml(r.valor || '') + '">Eliminar</button>'
+          : '<span class="text-muted small">Sin acciones disponibles</span>';
+
+        return '<tr><td>' + escaparHtml(r.valor || '') + '</td><td>' + escaparHtml(r.fecha || '-') + '</td><td class="text-end">' + acciones + '</td></tr>';
       }).join(''));
     }).fail(function() {
       $body.html('<tr><td colspan="3" class="text-center text-danger">No se pudieron cargar las solicitudes.</td></tr>');

--- a/App/js/AppRepartos.js
+++ b/App/js/AppRepartos.js
@@ -225,14 +225,17 @@ $(document).ready(function() {
         return;
       }
 
+      var puedeGestionarAcciones = respuesta.puedeGestionarAcciones === true;
       $body.html(respuesta.records.map(function(registro) {
+        var acciones = puedeGestionarAcciones
+          ? '<button type="button" class="btn btn-sm btn-primary atender-solicitud-cliente-reparto me-2" data-valor="' + escaparHtmlReparto(registro.valor || '') + '">Agregar</button>' +
+            '<button type="button" class="btn btn-sm btn-outline-danger eliminar-solicitud-cliente-reparto" data-id="' + escaparHtmlReparto(registro.id || '') + '" data-valor="' + escaparHtmlReparto(registro.valor || '') + '">Eliminar</button>'
+          : '<span class="text-muted small">Sin acciones disponibles</span>';
+
         return '<tr>' +
           '<td>' + escaparHtmlReparto(registro.valor || '') + '</td>' +
           '<td>' + escaparHtmlReparto(registro.fecha || '-') + '</td>' +
-          '<td class="text-end">' +
-            '<button type="button" class="btn btn-sm btn-primary atender-solicitud-cliente-reparto me-2" data-valor="' + escaparHtmlReparto(registro.valor || '') + '">Agregar</button>' +
-            '<button type="button" class="btn btn-sm btn-outline-danger eliminar-solicitud-cliente-reparto" data-id="' + escaparHtmlReparto(registro.id || '') + '" data-valor="' + escaparHtmlReparto(registro.valor || '') + '">Eliminar</button>' +
-          '</td>' +
+          '<td class="text-end">' + acciones + '</td>' +
         '</tr>';
       }).join(''));
     }).fail(function() {


### PR DESCRIPTION
### Motivation
- Evitar que usuarios sin el perfil Soporte IT (9) o Administrador (1) vean o ejecuten acciones sobre las solicitudes de clientes y productos, tanto en Material Pendiente como en el modal de Repartos.

### Description
- Añadí `puedeGestionarAccionesSolicitudes()` en `App/Server/ServerSolicitudesMaterialPendiente.php` que valida la sesión y permite solo `TIPOUSUARIO` 1 y 9 o los tipos `administrador`/`soporte it`, y agregué `session_start()` cuando falta la sesión.
- Bloqueé la acción `eliminar` en el servidor devolviendo `403` si `puedeGestionarAcciones` es `false` y añadí la bandera `puedeGestionarAcciones` en la respuesta JSON de listado.
- Oculté las acciones de fila en el cliente y muestro `Sin acciones disponibles` para usuarios no autorizados en `App/js/AppMaterialPendiente.js` reemplazando los botones `Agregar`/`Eliminar` por un mensaje cuando `respuesta.puedeGestionarAcciones !== true`.
- Apliqué la misma lógica visual en el listado de solicitudes de clientes usado por `App/js/AppRepartos.js` para mantener consistencia en la UI.

### Testing
- Ejecuté `php -l App/Server/ServerSolicitudesMaterialPendiente.php` y no hubo errores (sintaxis válida).
- Ejecuté `node --check App/js/AppMaterialPendiente.js` y `node --check App/js/AppRepartos.js` y ambos pasaron la comprobación de sintaxis.
- Ejecuté `git diff --check` y no reportó problemas en los cambios aplicados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c4c8d730083279cf3476965e34180)