### PR TITLE
Permitir acciones de reparto a perfiles Administrador, Supervisor y Soporte IT

### DIFF
--- a/App/Datatables/Repartidor-grid-data.php
+++ b/App/Datatables/Repartidor-grid-data.php
@@ -10,6 +10,10 @@ if (!isset($_SESSION)) {
 $tipoUsuarioActual = isset($_SESSION['TipoDeUsuario']) ? strtolower(trim((string) $_SESSION['TipoDeUsuario'])) : '';
 $tiposPermitidosCambioEstatus = ['soporte it', 'administrador', 'supervisor', 'auditor'];
 $puedeCambiarEstatus = $tipoUsuarioActual !== '' && in_array($tipoUsuarioActual, $tiposPermitidosCambioEstatus, true);
+$tiposUsuarioPermitidosAcciones = ['1', '6', '9'];
+$perfilesPermitidosAcciones = ['soporte it', 'administrador', 'supervisor'];
+$puedeGestionarAccionesRepartos = in_array((string) ($_SESSION['TIPOUSUARIO'] ?? ''), $tiposUsuarioPermitidosAcciones, true)
+    || ($tipoUsuarioActual !== '' && in_array($tipoUsuarioActual, $perfilesPermitidosAcciones, true));
 
 // storing  request (ie, get/post) global array to a variable
 $requestData = $_REQUEST;
@@ -119,7 +123,7 @@ while ($row = mysqli_fetch_array($query)) {  // preparing an array ... Preparand
         $BadgeStatus = '<span class="badge badge-success"  ' . $MandarModal . '>Recolectado</span>';
     }
 
-    if ($row['USUARIOID'] == $_SESSION['USUARIOID'] || $_SESSION['TIPOUSUARIO'] == '1') {
+    if ($row['USUARIOID'] == $_SESSION['USUARIOID'] || $puedeGestionarAccionesRepartos) {
 
         $BotonEditar = ' <button type="button" class="btn btn-sm btn-primary waves-effect width-md waves-light" data-bs-toggle="modal" data-bs-target="#ModalEditarReparto" onclick="TomarDatosParaModalRepartos(' . $row["REPARTOID"] . ')"><i class="mdi mdi-pencil"></i>Editar</button>';
     } else {
@@ -127,7 +131,7 @@ while ($row = mysqli_fetch_array($query)) {  // preparing an array ... Preparand
     }
 
 
-    if (($row['USUARIOID'] == $_SESSION['USUARIOID']) && ($row['STATUSID'] == '1') || $_SESSION['TIPOUSUARIO'] == '1') {
+    if ((($row['USUARIOID'] == $_SESSION['USUARIOID']) && ($row['STATUSID'] == '1')) || $puedeGestionarAccionesRepartos) {
 
         $BotonBorrar = '<button type="button" class="btn btn-sm btn-danger waves-effect width-md waves-light" data-bs-toggle="modal" data-bs-target="#ModalBorrarReparto" onclick="TomarDatosParaModalRepartos(' . $row["REPARTOID"] . ')"><i class="mdi mdi-pencil"></i>Borrar</button>';
     } else {

--- a/App/Datatables/Repartos-grid-data.php
+++ b/App/Datatables/Repartos-grid-data.php
@@ -10,6 +10,10 @@ if (!isset($_SESSION)) {
 $tipoUsuarioActual = isset($_SESSION['TipoDeUsuario']) ? strtolower(trim((string) $_SESSION['TipoDeUsuario'])) : '';
 $tiposPermitidosCambioEstatus = ['soporte it', 'administrador', 'supervisor', 'auditor'];
 $puedeCambiarEstatus = $tipoUsuarioActual !== '' && in_array($tipoUsuarioActual, $tiposPermitidosCambioEstatus, true);
+$tiposUsuarioPermitidosAcciones = ['1', '6', '9'];
+$perfilesPermitidosAcciones = ['soporte it', 'administrador', 'supervisor'];
+$puedeGestionarAccionesRepartos = in_array((string) ($_SESSION['TIPOUSUARIO'] ?? ''), $tiposUsuarioPermitidosAcciones, true)
+    || ($tipoUsuarioActual !== '' && in_array($tipoUsuarioActual, $perfilesPermitidosAcciones, true));
 
 // check request
 // storing request (ie, get/post) global array to a variable
@@ -227,19 +231,19 @@ while ($row = mysqli_fetch_array($query)) {  // preparing an array ... Preparand
         $BadgeStatus = '<span class="badge badge-success"  ' . $MandarModal . '>Recolectado</span>';
     }
 
-    if ($row['USUARIOID_US'] == $_SESSION['USUARIOID'] || $_SESSION['TIPOUSUARIO'] == '1') {
+    if ($row['USUARIOID_US'] == $_SESSION['USUARIOID'] || $puedeGestionarAccionesRepartos) {
         $BotonEditar = ' <button type="button" class="btn btn-sm btn-primary waves-effect width-md waves-light" data-bs-toggle="modal" data-bs-target="#ModalEditarReparto" onclick="TomarDatosParaModalRepartos(' . $row["REPARTOID"] . ')"><i class="mdi mdi-pencil"></i>Editar</button>';
     } else {
         $BotonEditar = '';
     }
 
-    if (($row['USUARIOID_US'] == $_SESSION['USUARIOID']) && ($row['STATUSID'] == '1') || $_SESSION['TIPOUSUARIO'] == '1') {
+    if ((($row['USUARIOID_US'] == $_SESSION['USUARIOID']) && ($row['STATUSID'] == '1')) || $puedeGestionarAccionesRepartos) {
         $BotonBorrar = '<button type="button" class="btn btn-sm btn-danger waves-effect width-md waves-light" data-bs-toggle="modal" data-bs-target="#ModalBorrarReparto" onclick="TomarDatosParaModalRepartos(' . $row["REPARTOID"] . ')"><i class="mdi mdi-pencil"></i>Borrar</button>';
     } else {
         $BotonBorrar = '';
     }
 
-    if ($row['USUARIOID_US'] == $_SESSION['USUARIOID'] || $_SESSION['TIPOUSUARIO'] == '1') {
+    if ($row['USUARIOID_US'] == $_SESSION['USUARIOID'] || $puedeGestionarAccionesRepartos) {
         $BotonClonar = ' <button type="button" class="btn btn-sm btn-dark waves-effect width-md waves-light" data-bs-toggle="modal" data-bs-target="#ModalClonarReparto" onclick="TomarDatosParaModalRepartos(' . $row["REPARTOID"] . ')"><i class="mdi mdi-pencil"></i>Clonar</button>';
     } else {
         $BotonClonar = '';

--- a/App/Datatables/RepartosCliente-grid-data.php
+++ b/App/Datatables/RepartosCliente-grid-data.php
@@ -9,6 +9,10 @@ if (!isset($_SESSION)) {
 $tipoUsuarioActual = isset($_SESSION['TipoDeUsuario']) ? strtolower(trim((string) $_SESSION['TipoDeUsuario'])) : '';
 $tiposPermitidosCambioEstatus = ['soporte it', 'administrador', 'supervisor', 'auditor'];
 $puedeCambiarEstatus = $tipoUsuarioActual !== '' && in_array($tipoUsuarioActual, $tiposPermitidosCambioEstatus, true);
+$tiposUsuarioPermitidosAcciones = ['1', '6', '9'];
+$perfilesPermitidosAcciones = ['soporte it', 'administrador', 'supervisor'];
+$puedeGestionarAccionesRepartos = in_array((string) ($_SESSION['TIPOUSUARIO'] ?? ''), $tiposUsuarioPermitidosAcciones, true)
+    || ($tipoUsuarioActual !== '' && in_array($tipoUsuarioActual, $perfilesPermitidosAcciones, true));
 
 // storing  request (ie, get/post) global array to a variable
 $requestData = $_REQUEST;
@@ -115,7 +119,7 @@ while ($row = mysqli_fetch_array($query)) {  // preparing an array ... Preparand
         $BadgeStatus = '<span class="badge badge-success"  ' . $MandarModal . '>Recolectado</span>';
     }
 
-    if ($row['USUARIOID'] == $_SESSION['USUARIOID'] || $_SESSION['TIPOUSUARIO'] == '1') {
+    if ($row['USUARIOID'] == $_SESSION['USUARIOID'] || $puedeGestionarAccionesRepartos) {
 
         $BotonEditar = ' <button type="button" class="btn btn-sm btn-primary waves-effect width-md waves-light" data-bs-toggle="modal" data-bs-target="#ModalEditarReparto" onclick="TomarDatosParaModalRepartos(' . $row["REPARTOID"] . ')"><i class="mdi mdi-pencil"></i>Editar</button>';
     } else {
@@ -123,7 +127,7 @@ while ($row = mysqli_fetch_array($query)) {  // preparing an array ... Preparand
     }
 
 
-    if (($row['USUARIOID'] == $_SESSION['USUARIOID']) && ($row['STATUSID'] == '1') || $_SESSION['TIPOUSUARIO'] == '1') {
+    if ((($row['USUARIOID'] == $_SESSION['USUARIOID']) && ($row['STATUSID'] == '1')) || $puedeGestionarAccionesRepartos) {
 
         $BotonBorrar = '<button type="button" class="btn btn-sm btn-danger waves-effect width-md waves-light" data-bs-toggle="modal" data-bs-target="#ModalBorrarReparto" onclick="TomarDatosParaModalRepartos(' . $row["REPARTOID"] . ')"><i class="mdi mdi-pencil"></i>Borrar</button>';
     } else {

--- a/App/Datatables/RepartosCliente-grid-data1.php
+++ b/App/Datatables/RepartosCliente-grid-data1.php
@@ -9,6 +9,10 @@ if (!isset($_SESSION)) {
 $tipoUsuarioActual = isset($_SESSION['TipoDeUsuario']) ? strtolower(trim((string) $_SESSION['TipoDeUsuario'])) : '';
 $tiposPermitidosCambioEstatus = ['soporte it', 'administrador', 'supervisor', 'auditor'];
 $puedeCambiarEstatus = $tipoUsuarioActual !== '' && in_array($tipoUsuarioActual, $tiposPermitidosCambioEstatus, true);
+$tiposUsuarioPermitidosAcciones = ['1', '6', '9'];
+$perfilesPermitidosAcciones = ['soporte it', 'administrador', 'supervisor'];
+$puedeGestionarAccionesRepartos = in_array((string) ($_SESSION['TIPOUSUARIO'] ?? ''), $tiposUsuarioPermitidosAcciones, true)
+    || ($tipoUsuarioActual !== '' && in_array($tipoUsuarioActual, $perfilesPermitidosAcciones, true));
 
 // storing  request (ie, get/post) global array to a variable
 $requestData = $_REQUEST;
@@ -116,7 +120,7 @@ while ($row = mysqli_fetch_array($query)) {  // preparing an array ... Preparand
         $BadgeStatus = '<span class="badge badge-success"  ' . $MandarModal . '>Recolectado</span>';
     }
 
-    if ($row['USUARIOID'] == $_SESSION['USUARIOID'] || $_SESSION['TIPOUSUARIO'] == '1') {
+    if ($row['USUARIOID'] == $_SESSION['USUARIOID'] || $puedeGestionarAccionesRepartos) {
 
         $BotonEditar = ' <button type="button" class="btn btn-sm btn-primary waves-effect width-md waves-light" data-bs-toggle="modal" data-bs-target="#ModalEditarReparto" onclick="TomarDatosParaModalRepartos(' . $row["REPARTOID"] . ')"><i class="mdi mdi-pencil"></i>Editar</button>';
     } else {
@@ -124,7 +128,7 @@ while ($row = mysqli_fetch_array($query)) {  // preparing an array ... Preparand
     }
 
 
-    if (($row['USUARIOID'] == $_SESSION['USUARIOID']) && ($row['STATUSID'] == '1') || $_SESSION['TIPOUSUARIO'] == '1') {
+    if ((($row['USUARIOID'] == $_SESSION['USUARIOID']) && ($row['STATUSID'] == '1')) || $puedeGestionarAccionesRepartos) {
 
         $BotonBorrar = '<button type="button" class="btn btn-sm btn-danger waves-effect width-md waves-light" data-bs-toggle="modal" data-bs-target="#ModalBorrarReparto" onclick="TomarDatosParaModalRepartos(' . $row["REPARTOID"] . ')"><i class="mdi mdi-pencil"></i>Borrar</button>';
     } else {


### PR DESCRIPTION
### Motivation
- Los botones de acción (Editar, Borrar, Clonar) en el módulo de reparto sólo se mostraban al usuario que creó el registro o al Administrador (1), y se requiere que también sean visibles para los perfiles Soporte IT (9) y Supervisor (6).

### Description
- Añadí en los datatables una verificación común que define `tiposUsuarioPermitidosAcciones = ['1','6','9']` y `perfilesPermitidosAcciones = ['soporte it','administrador','supervisor']` y calcula `puedeGestionarAccionesRepartos` para permitir acciones a esos perfiles además del creador.
- Reemplacé las condiciones existentes que comprobaban `$_SESSION['TIPOUSUARIO'] == '1'` o si el registro pertenece al usuario por comprobaciones que usan `puedeGestionarAccionesRepartos` en lugar de sólo el Administrador.
- Los cambios se aplicaron en los archivos `App/Datatables/Repartos-grid-data.php`, `App/Datatables/RepartosCliente-grid-data.php`, `App/Datatables/RepartosCliente-grid-data1.php` y `App/Datatables/Repartidor-grid-data.php`, afectando la visibilidad de los botones `Editar`, `Borrar` y `Clonar`.

### Testing
- Ejecuté `php -l App/Datatables/Repartos-grid-data.php`, `php -l App/Datatables/RepartosCliente-grid-data.php`, `php -l App/Datatables/RepartosCliente-grid-data1.php` y `php -l App/Datatables/Repartidor-grid-data.php` y no se reportaron errores de sintaxis.
- Verifiqué `git diff --check` para asegurar que no haya problemas de formato en las diferencias y la verificación pasó sin advertencias.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c501c7af88327ba3112338dbd487d)