### PR TITLE
Restringir edición y eliminación de repartos no registrados

### DIFF
--- a/App/Datatables/Repartos-grid-data.php
+++ b/App/Datatables/Repartos-grid-data.php
@@ -231,13 +231,15 @@ while ($row = mysqli_fetch_array($query)) {  // preparing an array ... Preparand
         $BadgeStatus = '<span class="badge badge-success"  ' . $MandarModal . '>Recolectado</span>';
     }
 
-    if ($row['USUARIOID_US'] == $_SESSION['USUARIOID'] || $puedeGestionarAccionesRepartos) {
+    $repartoRegistrado = strcasecmp(trim((string) ($row['Status'] ?? '')), 'Registrado') === 0;
+
+    if ($repartoRegistrado && ($row['USUARIOID_US'] == $_SESSION['USUARIOID'] || $puedeGestionarAccionesRepartos)) {
         $BotonEditar = ' <button type="button" class="btn btn-sm btn-primary waves-effect width-md waves-light" data-bs-toggle="modal" data-bs-target="#ModalEditarReparto" onclick="TomarDatosParaModalRepartos(' . $row["REPARTOID"] . ')"><i class="mdi mdi-pencil"></i>Editar</button>';
     } else {
         $BotonEditar = '';
     }
 
-    if ((($row['USUARIOID_US'] == $_SESSION['USUARIOID']) && ($row['STATUSID'] == '1')) || $puedeGestionarAccionesRepartos) {
+    if ($repartoRegistrado && ($row['USUARIOID_US'] == $_SESSION['USUARIOID'] || $puedeGestionarAccionesRepartos)) {
         $BotonBorrar = '<button type="button" class="btn btn-sm btn-danger waves-effect width-md waves-light" data-bs-toggle="modal" data-bs-target="#ModalBorrarReparto" onclick="TomarDatosParaModalRepartos(' . $row["REPARTOID"] . ')"><i class="mdi mdi-pencil"></i>Borrar</button>';
     } else {
         $BotonBorrar = '';

--- a/App/Server/ServerBorrarRepartos.php
+++ b/App/Server/ServerBorrarRepartos.php
@@ -4,6 +4,17 @@ include("../../Connections/ConDB.php");
 
 $REPARTOID = mysqli_real_escape_string($conn, $_POST['REPARTOID']);
 
+$consultaEstatus = mysqli_query($conn, "SELECT status.Status FROM repartos LEFT JOIN status ON status.STATUSID = repartos.STATUSID WHERE repartos.REPARTOID = '$REPARTOID' LIMIT 1");
+$repartoActual = $consultaEstatus ? mysqli_fetch_assoc($consultaEstatus) : null;
+
+if (!$repartoActual || strcasecmp(trim((string) ($repartoActual['Status'] ?? '')), 'Registrado') !== 0) {
+    http_response_code(409);
+    echo json_encode(array(
+        'error' => 'Solo se pueden eliminar repartos con estatus Registrado.'
+    ));
+    exit;
+}
+
 // Build the base query
 $sql = "DELETE FROM repartos
     WHERE REPARTOID = '$REPARTOID'";

--- a/App/Server/ServerUpdateRepartos.php
+++ b/App/Server/ServerUpdateRepartos.php
@@ -20,11 +20,21 @@ $REPARTOID = mysqli_real_escape_string($conn, $_POST['REPARTOIDEditar']);
 
 $EnlaceGoogleMaps = !empty($_POST['EnlaceGoogleMapsEditar']) ? mysqli_real_escape_string($conn, $_POST['EnlaceGoogleMapsEditar']) : NULL;
 
+$consultaEstatus = mysqli_query($conn, "SELECT status.Status FROM repartos LEFT JOIN status ON status.STATUSID = repartos.STATUSID WHERE repartos.REPARTOID = '$REPARTOID' LIMIT 1");
+$repartoActual = $consultaEstatus ? mysqli_fetch_assoc($consultaEstatus) : null;
+
+if (!$repartoActual || strcasecmp(trim((string) ($repartoActual['Status'] ?? '')), 'Registrado') !== 0) {
+    http_response_code(409);
+    echo json_encode(array(
+        'error' => 'Solo se pueden editar repartos con estatus Registrado.'
+    ));
+    exit;
+}
 
 if ($EnlaceGoogleMaps !== NULL) {
 
     // Build the base query
-    $sql = "UPDATE repartos SET 
+    $sql = "UPDATE repartos SET
     CLIENTEID = '$CLIENTEID',
     NumeroDeFactura = '$NumeroDeFactura',
     Calle = '$Calle',
@@ -42,7 +52,7 @@ if ($EnlaceGoogleMaps !== NULL) {
 } else {
 
     // Build the base query
-    $sql = "UPDATE repartos SET 
+    $sql = "UPDATE repartos SET
     CLIENTEID = '$CLIENTEID',
     NumeroDeFactura = '$NumeroDeFactura',
     Calle = '$Calle',


### PR DESCRIPTION
### Motivation
- Evitar que los usuarios editen o eliminen repartos una vez que su estatus cambia de "Registrado", ya que el administrador reportó ediciones posteriores que generan confusión en el flujo.

### Description
- En `App/Datatables/Repartos-grid-data.php` se añadió la comprobación de si el reparto está en estatus `Registrado` y solo en ese caso se muestran los botones `Editar` y `Borrar` para usuarios autorizados. 
- En `App/Server/ServerUpdateRepartos.php` se añadió validación previa a la actualización que verifica el estatus real del reparto (uniendo con la tabla `status`) y devuelve `409` con un mensaje cuando no es `Registrado`.
- En `App/Server/ServerBorrarRepartos.php` se añadió la misma validación previa al borrado y se rechaza la operación con `409` cuando el estatus no es `Registrado`.

### Testing
- Se ejecutó `php -l App/Datatables/Repartos-grid-data.php` y la verificación fue exitosa. 
- Se ejecutó `php -l App/Server/ServerUpdateRepartos.php` y la verificación fue exitosa. 
- Se ejecutó `php -l App/Server/ServerBorrarRepartos.php` y la verificación fue exitosa. 
- Se ejecutó `git diff --check` y no se encontraron errores de diff; los cambios fueron confirmados en un commit exitoso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a443b15bf008327aaf17d4b9340dd33)